### PR TITLE
feat: 파트별 메모 CRUD 기능 구현 및 피그마 디자인 반영

### DIFF
--- a/lib/common/time_helper.dart
+++ b/lib/common/time_helper.dart
@@ -11,6 +11,14 @@ String ymdHm(DateTime dt) {
          '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
 }
 
+String mdHm(DateTime dt) {
+  // 예: 11월 10일 오후 08:00
+  final localDt = dt.toLocal();
+  final amPm = localDt.hour < 12 ? '오전' : '오후';
+  final hour = localDt.hour == 0 ? 12 : (localDt.hour > 12 ? localDt.hour - 12 : localDt.hour);
+  return '${localDt.month}월 ${localDt.day}일 $amPm ${hour.toString().padLeft(2, '0')}:${localDt.minute.toString().padLeft(2, '0')}';
+}
+
 extension MilliSecondsExt on int {
   int toSec() => this ~/ 1000; // 몫 연산
 }

--- a/lib/db/app_db.dart
+++ b/lib/db/app_db.dart
@@ -1859,6 +1859,34 @@ class AppDb extends _$AppDb {
     )..where((t) => t.id.equals(noteId))).getSingleOrNull();
   }
 
+  /// PartNote 핀 고정 상태 토글
+  ///
+  /// [noteId]: PartNote ID
+  Future<void> togglePartNotePin(int noteId) async {
+    final note = await getPartNote(noteId);
+    if (note == null) return;
+
+    await (update(partNotes)..where((t) => t.id.equals(noteId))).write(
+      PartNotesCompanion(
+        isPinned: Value(!note.isPinned),
+        updatedAt: Value(DateTime.now().toUtc()),
+      ),
+    );
+  }
+
+  /// Part의 메모 개수 조회 (Stream)
+  ///
+  /// [partId]: Part ID
+  ///
+  /// 반환값: PartNote 개수 Stream
+  Stream<int> watchPartNotesCount(int partId) {
+    final query = selectOnly(partNotes)
+      ..addColumns([partNotes.id.count()])
+      ..where(partNotes.partId.equals(partId));
+
+    return query.map((row) => row.read(partNotes.id.count()) ?? 0).watchSingle();
+  }
+
   // ────────────────────────────────────────────────────────────────────────────
   // Tag 관련 메서드들
   // ────────────────────────────────────────────────────────────────────────────

--- a/lib/project_detail_screen.dart
+++ b/lib/project_detail_screen.dart
@@ -22,6 +22,7 @@ import 'package:yarnie/widgets/counter_card/shaping_counter_card.dart';
 import 'package:yarnie/widgets/counter_card/stitch_counter_card.dart';
 import 'package:yarnie/widgets/counter_edit_bottom_sheet.dart';
 import 'package:yarnie/widgets/main_counter_settings_button.dart';
+import 'package:yarnie/widgets/part_memo_sheet.dart';
 import 'package:yarnie/widgets/target_setting_dialog.dart';
 // import 'package:yarnie/stopwatch_panel.dart'; // 기존 패널 미사용
 // import 'package:yarnie/counter_panel.dart';   // 기존 패널 미사용
@@ -368,8 +369,24 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
             children: [
               // Memo Button
               GestureDetector(
-                onTap: () {
-                  // TODO: Open Part Memo
+                onTap: () async {
+                  if (_selectedPartId == null) return;
+                  
+                  // 파트 이름 가져오기
+                  final part = await appDb.getPart(_selectedPartId!);
+                  final partName = part?.name ?? '파트';
+
+                  if (context.mounted) {
+                    showModalBottomSheet(
+                      context: context,
+                      isScrollControlled: true,
+                      backgroundColor: Colors.transparent,
+                      builder: (context) => PartMemoSheet(
+                        partId: _selectedPartId!,
+                        partName: partName,
+                      ),
+                    );
+                  }
                 },
                 child: Stack(
                   clipBehavior: Clip.none,
@@ -382,27 +399,36 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
                       ),
                       child: const Icon(Icons.description_outlined, size: 24, color: Color(0xFF717182)),
                     ),
-                    Positioned(
-                      right: -2,
-                      top: -4,
-                      child: Container(
-                        width: 16,
-                        height: 16,
-                        decoration: const BoxDecoration(
-                          color: Color(0xFF637069),
-                          shape: BoxShape.circle,
-                        ),
-                        alignment: Alignment.center,
-                        child: const Text(
-                          '2', // TODO: Real memo count
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 10,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
+                    if (_selectedPartId != null)
+                      StreamBuilder<int>(
+                        stream: appDb.watchPartNotesCount(_selectedPartId!),
+                        builder: (context, snapshot) {
+                          final count = snapshot.data ?? 0;
+                          if (count == 0) return const SizedBox.shrink();
+                          
+                          return Positioned(
+                            right: -2,
+                            top: -4,
+                            child: Container(
+                              width: 16,
+                              height: 16,
+                              decoration: const BoxDecoration(
+                                color: Color(0xFF637069),
+                                shape: BoxShape.circle,
+                              ),
+                              alignment: Alignment.center,
+                              child: Text(
+                                '$count',
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          );
+                        },
                       ),
-                    )
                   ],
                 ),
               ),

--- a/lib/widgets/part_memo_sheet.dart
+++ b/lib/widgets/part_memo_sheet.dart
@@ -1,0 +1,544 @@
+import 'package:flutter/material.dart';
+import 'package:yarnie/db/app_db.dart';
+import 'package:yarnie/db/di.dart';
+import 'package:yarnie/common/time_helper.dart';
+
+class PartMemoSheet extends StatefulWidget {
+  final int partId;
+  final String partName;
+
+  const PartMemoSheet({
+    super.key,
+    required this.partId,
+    required this.partName,
+  });
+
+  @override
+  State<PartMemoSheet> createState() => _PartMemoSheetState();
+}
+
+class _PartMemoSheetState extends State<PartMemoSheet> {
+  final TextEditingController _textController = TextEditingController();
+  bool _isInputValid = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _textController.addListener(_validateInput);
+  }
+
+  @override
+  void dispose() {
+    _textController.removeListener(_validateInput);
+    _textController.dispose();
+    super.dispose();
+  }
+
+  void _validateInput() {
+    final isValid = _textController.text.trim().isNotEmpty;
+    if (_isInputValid != isValid) {
+      setState(() {
+        _isInputValid = isValid;
+      });
+    }
+  }
+
+  Future<void> _addMemo() async {
+    final content = _textController.text.trim();
+    if (content.isEmpty) return;
+
+    await appDb.createPartNote(
+      partId: widget.partId,
+      content: content,
+    );
+    _textController.clear();
+    FocusScope.of(context).unfocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(10),
+          topRight: Radius.circular(10),
+        ),
+      ),
+      child: SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Handle Bar
+            Center(
+              child: Container(
+                margin: const EdgeInsets.only(top: 16, bottom: 8),
+                width: 100,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFECECF0),
+                  borderRadius: BorderRadius.circular(100),
+                ),
+              ),
+            ),
+
+            // Header
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${widget.partName} - 메모',
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: Color(0xFF0A0A0A),
+                      letterSpacing: -0.31,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  const Text(
+                    '파트에 대한 메모를 추가하거나 수정하세요.',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Color(0xFF717182),
+                      letterSpacing: -0.15,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Input Section
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Column(
+                children: [
+                  Container(
+                    height: 80,
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFF3F3F5),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: TextField(
+                      controller: _textController,
+                      maxLines: null,
+                      style: const TextStyle(fontSize: 16, color: Color(0xFF0A0A0A)),
+                      decoration: const InputDecoration(
+                        hintText: '새 메모를 입력하세요...',
+                        hintStyle: TextStyle(color: Color(0xFF717182)),
+                        border: InputBorder.none,
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(vertical: 8),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  GestureDetector(
+                    onTap: _isInputValid ? _addMemo : null,
+                    child: Container(
+                      height: 36,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF637069).withValues(alpha: _isInputValid ? 1.0 : 0.5),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: const [
+                          Icon(Icons.add, size: 16, color: Colors.white),
+                          SizedBox(width: 4),
+                          Text(
+                            '메모 추가',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w500,
+                              color: Colors.white,
+                              letterSpacing: -0.15,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // Memo List Section
+            Flexible(
+              child: StreamBuilder<List<PartNote>>(
+                stream: appDb.watchPartNotes(widget.partId),
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  final notes = snapshot.data!;
+                  if (notes.isEmpty) {
+                    return const Padding(
+                      padding: EdgeInsets.only(bottom: 16),
+                      child: Center(
+                        child: Text(
+                          '등록된 메모가 없습니다.',
+                          style: TextStyle(color: Color(0xFF717182)),
+                        ),
+                      ),
+                    );
+                  }
+
+                  return ListView.builder(
+                    shrinkWrap: true,
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                    itemCount: notes.length,
+                    itemBuilder: (context, index) {
+                      final note = notes[index];
+                      return _MemoCard(note: note);
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MemoCard extends StatelessWidget {
+  final PartNote note;
+
+  const _MemoCard({required this.note});
+
+  void _showActionSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (context) => _MemoActionSheet(note: note),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onLongPress: () {
+        _showActionSheet(context);
+      },
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 12),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: const Color(0x1A000000), width: 0.64),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Text(
+                      note.content,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        color: Color(0xFF0A0A0A),
+                        letterSpacing: -0.15,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  if (note.isPinned)
+                    const Icon(
+                      Icons.push_pin,
+                      size: 16,
+                      color: Color(0xFFD4183D),
+                    ),
+                ],
+              ),
+            ),
+            Container(
+              height: 0.64,
+              color: const Color(0x1A000000),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: Text(
+                mdHm(note.createdAt),
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: Color(0xFF717182),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MemoActionSheet extends StatelessWidget {
+  final PartNote note;
+
+  const _MemoActionSheet({required this.note});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(10),
+          topRight: Radius.circular(10),
+        ),
+      ),
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Handle Bar
+              Center(
+                child: Container(
+                  margin: const EdgeInsets.only(top: 16, bottom: 16),
+                  width: 100,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFECECF0),
+                    borderRadius: BorderRadius.circular(100),
+                  ),
+                ),
+              ),
+              // Menu List
+              _ActionButton(
+                label: note.isPinned ? '상단 고정 해제' : '상단에 고정',
+                icon: Icons.push_pin_outlined,
+                backgroundColor: const Color(0xFF637069),
+                textColor: Colors.white,
+                iconColor: Colors.white,
+                onTap: () {
+                  appDb.togglePartNotePin(note.id);
+                  Navigator.pop(context);
+                },
+              ),
+              const SizedBox(height: 8),
+              _ActionButton(
+                label: '수정',
+                icon: Icons.edit_outlined,
+                backgroundColor: Colors.white,
+                textColor: const Color(0xFF0A0A0A),
+                iconColor: const Color(0xFF0A0A0A),
+                showBorder: true,
+                onTap: () {
+                  Navigator.pop(context);
+                  _showEditDialog(context);
+                },
+              ),
+              const SizedBox(height: 8),
+              _ActionButton(
+                label: '삭제',
+                icon: Icons.delete_outline,
+                backgroundColor: Colors.white,
+                textColor: const Color(0xFFD4183D),
+                iconColor: const Color(0xFFD4183D),
+                showBorder: true,
+                onTap: () {
+                  appDb.deletePartNote(note.id);
+                  Navigator.pop(context);
+                },
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showEditDialog(BuildContext context) {
+    final controller = TextEditingController(text: note.content);
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => Container(
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(10),
+            topRight: Radius.circular(10),
+          ),
+        ),
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Handle Bar
+              Center(
+                child: Container(
+                  margin: const EdgeInsets.only(top: 16, bottom: 8),
+                  width: 100,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFECECF0),
+                    borderRadius: BorderRadius.circular(100),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Text(
+                      '메모 수정',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        color: Color(0xFF0A0A0A),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Container(
+                      height: 120,
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFF3F3F5),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: TextField(
+                        controller: controller,
+                        maxLines: null,
+                        autofocus: true,
+                        style: const TextStyle(fontSize: 16, color: Color(0xFF0A0A0A)),
+                        decoration: const InputDecoration(
+                          border: InputBorder.none,
+                          isDense: true,
+                          contentPadding: EdgeInsets.symmetric(vertical: 8),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: GestureDetector(
+                            onTap: () => Navigator.pop(context),
+                            child: Container(
+                              height: 48,
+                              alignment: Alignment.center,
+                              decoration: BoxDecoration(
+                                color: Colors.white,
+                                border: Border.all(color: const Color(0x1A000000)),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: const Text('취소'),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: GestureDetector(
+                            onTap: () {
+                              final newContent = controller.text.trim();
+                              if (newContent.isNotEmpty) {
+                                appDb.updatePartNote(
+                                  noteId: note.id,
+                                  content: newContent,
+                                );
+                              }
+                              Navigator.pop(context);
+                            },
+                            child: Container(
+                              height: 48,
+                              alignment: Alignment.center,
+                              decoration: BoxDecoration(
+                                color: const Color(0xFF637069),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: const Text(
+                                '저장',
+                                style: TextStyle(color: Colors.white),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  final String label;
+  final IconData icon;
+  final Color backgroundColor;
+  final Color textColor;
+  final Color iconColor;
+  final bool showBorder;
+  final VoidCallback onTap;
+
+  const _ActionButton({
+    required this.label,
+    required this.icon,
+    required this.backgroundColor,
+    required this.textColor,
+    required this.iconColor,
+    this.showBorder = false,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: 36,
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(8),
+          border: showBorder ? Border.all(color: const Color(0x1A000000), width: 0.694) : null,
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, size: 16, color: iconColor),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: textColor,
+                letterSpacing: -0.15,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
* 데이터베이스 및 로직 확장
  - 파트별 메모 개수 실시간 조회(watchPartNotesCount) 및 핀 토글(togglePartNotePin) 메서드 추가
  - 메모 전용 날짜 포맷터(mdHm) 구현 (예: 11월 10일 오후 08:00)

* 파트 메모 UI 구현 (PartMemoSheet)
  - 피그마 디자인 사양을 반영한 가변형 바텀 시트 레이아웃 구축 (최대 높이 85%)
  - 메모 추가, 수정, 삭제 및 핀 고정 기능 통합 관리
  - 핀 고정된 메모 상단 정렬 및 시각적 표시(붉은색 핀 아이콘) 로직 적용

* 사용자 인터랙션 기능
  - 메모 카드 롱프레스 시 액션 메뉴 시트(고정/수정/삭제) 호출 기능 구현
  - 기존 스와이프 삭제 방식을 롱프레스 메뉴 방식으로 변경하여 의도치 않은 삭제 방지

* 프로젝트 상세 화면 연동
  - 헤더의 메모 아이콘 클릭 시 현재 선택된 파트의 메모 시트 호출 연동
  - 아이콘 상단 배지에 실제 메모 개수를 실시간(Stream)으로 반영