### PR TITLE
프로젝트 카드 더보기 버튼 제거, 롱프레스 메뉴로 전환

### DIFF
--- a/.kiro/specs/ui-ux-system/requirements.md
+++ b/.kiro/specs/ui-ux-system/requirements.md
@@ -54,11 +54,10 @@
 
 #### Acceptance Criteria
 
-1. WHEN 프로젝트 목록이 표시될 때, THE UI_System SHALL 각 프로젝트 카드에 이름, 카테고리, 생성일, 마지막 작업일을 표시한다
-2. WHEN 프로젝트에 활성 세션이 있을 때, THE UI_System SHALL 해당 프로젝트 카드에 "작업 중" 배지를 표시한다
-3. WHEN 프로젝트 카드를 탭할 때, THE UI_System SHALL 해당 프로젝트의 상세 화면으로 이동한다
-4. WHEN 프로젝트 목록이 비어있을 때, THE UI_System SHALL 빈 상태 일러스트와 "프로젝트 만들기" 버튼을 표시한다
-5. WHEN 프로젝트를 길게 누를 때, THE UI_System SHALL 편집/삭제 컨텍스트 메뉴를 표시한다
+1. WHEN 프로젝트 목록이 표시될 때, THE UI_System SHALL 각 프로젝트 카드에 이름, 태그, 프로젝트 생성일을 표시한다
+2. WHEN 프로젝트 카드를 탭할 때, THE UI_System SHALL 해당 프로젝트의 상세 화면으로 이동한다
+3. WHEN 프로젝트 목록이 비어있을 때, THE UI_System SHALL 빈 상태 일러스트와 "프로젝트 만들기" 버튼을 표시한다
+4. WHEN 프로젝트를 길게 누를 때, THE UI_System SHALL 프로젝트 복사, 태그 지정 메뉴를 표시한다
 
 ### Requirement 4
 
@@ -67,13 +66,10 @@
 #### Acceptance Criteria
 
 1. WHEN 프로젝트 상세 화면이 표시될 때, THE UI_System SHALL 상단에 해당 프로젝트의 모든 Part를 탭 형태로 표시한다
-2. WHEN Part 탭을 표시할 때, THE UI_System SHALL 각 Part의 이름과 현재 MainCounter 값을 포함한다
-3. WHEN Part 탭을 선택할 때, THE UI_System SHALL 해당 Part의 Counter와 Session 데이터를 하단에 표시한다
-4. WHEN 활성 세션이 있는 Part일 때, THE UI_System SHALL 해당 탭에 타이머 아이콘이나 진행 표시를 추가한다
-5. WHEN Part가 1개뿐일 때, THE UI_System SHALL 탭 네비게이션을 숨기고 Part 이름만 표시한다
-6. WHEN "+" 버튼을 탭할 때, THE UI_System SHALL 새 Part 생성 다이얼로그를 표시한다
-7. WHEN 프로젝트 상세 화면 상단에 메뉴 버튼(⋮)을 표시할 때, THE UI_System SHALL 앱바 우상단에 배치한다
-8. WHEN 메뉴 버튼을 탭할 때, THE UI_System SHALL 프로젝트 정보 보기/편집 옵션을 포함한 드롭다운 메뉴를 표시한다
+2. WHEN Part 탭을 선택할 때, THE UI_System SHALL 해당 Part의 Counter와 Session 데이터를 하단에 표시한다
+3. WHEN "+ 새파트" 버튼을 탭할 때, THE UI_System SHALL 새 Part 생성 다이얼로그를 표시한다
+4. WHEN 프로젝트 상세 화면 상단에 메뉴 버튼(⋮)을 표시할 때, THE UI_System SHALL 앱바 우상단에 배치한다
+5. WHEN 메뉴 버튼을 탭할 때, THE UI_System SHALL 프로젝트 정보 보기/편집 옵션을 포함한 드롭다운 메뉴를 표시한다
 
 ### Requirement 5
 
@@ -85,9 +81,9 @@
 2. WHEN MainCounter를 표시할 때, THE UI_System SHALL 2x1 크기(전체 너비)로 배치하고 현재 값, +/- 버튼을 포함한다
 3. WHEN BuddyCounter들이 있을 때, THE UI_System SHALL MainCounter 아래에 1x1 크기로 2열 구조로 배치한다
 4. WHEN Stitch Counter를 표시할 때, THE UI_System SHALL 이름, 현재 값, +/- 버튼을 포함한다
-5. WHEN Section Counter를 표시할 때, THE UI_System SHALL 이름, 진행률, 링크 상태 배지를 포함한다
-6. WHEN Section Counter가 unlinked 상태일 때, THE UI_System SHALL "연결 해제됨" 배지를 표시한다
-7. WHEN "버디 카운터 추가" 버튼을 탭할 때, THE UI_System SHALL Stitch/Section 선택 다이얼로그를 표시한다
+5. WHEN Section Counter를 표시할 때, THE UI_System SHALL 이름, 진행률, 링크 상태 버튼, 설정 버튼을 포함한다
+6. WHEN Section Counter가 unlinked 상태일 때, THE UI_System SHALL 링크 상태 버튼을 "링크 해제됨" 아이콘을 표시한다
+7. WHEN "버디 카운터 추가" 버튼을 탭할 때, THE UI_System SHALL Stitch와 Section 모든 유형 선택 메뉴를 표시한다
 8. WHEN BuddyCounter가 홀수 개일 때, THE UI_System SHALL 마지막 카운터를 왼쪽에 배치하고 오른쪽은 빈 공간으로 둔다
 9. WHEN BuddyCounter가 많아질 때, THE UI_System SHALL 2열 그리드를 유지하면서 세로로 스크롤 가능하도록 배치한다
 10. WHEN BuddyCounter를 길게 누를 때, THE UI_System SHALL 드래그 모드로 전환하고 카운터에 시각적 피드백(그림자, 확대 등)을 제공한다
@@ -103,8 +99,8 @@
 
 1. WHEN Session 패널이 표시될 때, THE UI_System SHALL Part 탭 바로 아래에 띠배너 형태로 배치하고 현재 세션의 상태(running/paused/stopped)를 명확히 표시한다
 2. WHEN 세션이 running 상태일 때, THE UI_System SHALL 실시간 타이머와 일시정지 버튼을 표시한다
-3. WHEN 세션이 paused 상태일 때, THE UI_System SHALL 누적 시간과 재시작/종료 버튼을 표시한다
-4. WHEN 세션이 없을 때, THE UI_System SHALL "작업 시작" 버튼을 표시한다
+3. WHEN 세션이 paused 상태일 때, THE UI_System SHALL 누적 시간과 이어하기 버튼을 표시한다
+4. WHEN 세션이 없을 때, THE UI_System SHALL "시작" 버튼을 표시한다
 5. WHEN 백그라운드에서 세션이 진행 중일 때, THE UI_System SHALL 알림 표시와 함께 현재 시간을 업데이트한다
 6. WHEN 세션 종료 버튼을 탭할 때, THE UI_System SHALL 세션 완료 다이얼로그를 표시한다
 
@@ -118,8 +114,6 @@
 2. WHEN 상위 유형을 선택할 때, THE UI_System SHALL 해당 유형의 하위 옵션들을 목록으로 표시한다
 3. WHEN 하위 옵션을 선택할 때, THE UI_System SHALL 해당 옵션에 맞는 설정 폼을 표시한다
 4. WHEN Length Type을 선택할 때, THE UI_System SHALL 프로젝트 게이지 정보가 있으면 자동으로 채우고, 없으면 입력 필드를 표시한다
-5. WHEN 설정을 완료할 때, THE UI_System SHALL 미리보기와 함께 확인 버튼을 표시한다
-6. WHEN 뒤로가기를 할 때, THE UI_System SHALL 입력된 데이터 손실 경고를 표시한다
 
 ### Requirement 8
 
@@ -183,13 +177,11 @@
 
 #### Acceptance Criteria
 
-1. WHEN 프로젝트 생성 화면이 표시될 때, THE UI_System SHALL 빈 입력 폼과 "프로젝트 만들기" 제목을 표시한다
-2. WHEN 프로젝트 편집 화면이 표시될 때, THE UI_System SHALL 기존 데이터가 채워진 폼과 "프로젝트 정보" 제목을 표시한다
-3. WHEN 입력 폼을 표시할 때, THE UI_System SHALL 프로젝트 이름(필수), 카테고리, 바늘 종류/크기, 로트 번호, 메모 필드를 포함한다
-4. WHEN 프로젝트 이름이 비어있을 때, THE UI_System SHALL 저장 버튼을 비활성화하고 유효성 메시지를 표시한다
-5. WHEN 저장 버튼을 탭할 때, THE UI_System SHALL 데이터 저장 후 성공 메시지를 표시하고 이전 화면으로 돌아간다
-6. WHEN 편집 모드에서 삭제 옵션을 제공할 때, THE UI_System SHALL 위험 색상과 확인 다이얼로그를 포함한다
-7. WHEN 게이지 정보 입력 섹션을 표시할 때, THE UI_System SHALL 선택적 입력으로 구성하고 단위 선택을 포함한다
+1. WHEN 프로젝트 생성 화면이 표시될 때, THE UI_System SHALL 빈 입력 폼과 "새 프로젝트" 제목을 표시한다
+2. WHEN 프로젝트 편집 화면이 표시될 때, THE UI_System SHALL 기존 데이터가 채워진 폼과 "프로젝트 수정" 제목을 표시한다
+3. WHEN 입력 폼을 표시할 때, THE UI_System SHALL 프로젝트 이름(필수), 프로젝트 이미지, 바늘 종류/크기, 로트 번호, 태그 목록, 메모 필드, 게이지 필드를 포함한다
+4. WHEN 프로젝트 이름을 비운 채로 저장 버튼을 누를 때, THE UI_System SHALL "프로젝트 이름을 입력해주세요"라는 유효성 메시지를 표시한다
+5. WHEN 저장 버튼을 탭할 때, THE UI_System SHALL 데이터 저장 후 성공 메시지를 표시하고 프로젝트 상세 화면으로 이동한다
 
 ### Requirement 13
 

--- a/lib/features/projects/projects_root.dart
+++ b/lib/features/projects/projects_root.dart
@@ -155,21 +155,21 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
           projects: projects,
           tags: state.allTags,
           onProjectTap: (id) => _openProject(id),
-          onMoreTap: (id) => _showProjectMenu(id),
+          onLongPress: (id) => _showProjectMenu(id),
         );
       case ProjectViewMode.smallCard:
         return _SmallCardView(
           projects: projects,
           tags: state.allTags,
           onProjectTap: (id) => _openProject(id),
-          onMoreTap: (id) => _showProjectMenu(id),
+          onLongPress: (id) => _showProjectMenu(id),
         );
       case ProjectViewMode.list:
         return _ListView(
           projects: projects,
           tags: state.allTags,
           onProjectTap: (id) => _openProject(id),
-          onMoreTap: (id) => _showProjectMenu(id),
+          onLongPress: (id) => _showProjectMenu(id),
         );
     }
   }
@@ -216,17 +216,22 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
     }
   }
 
-  Future<void> _showTagAssignmentSheet(BuildContext context, int projectId, List<int> currentTagIds) async {
+  Future<void> _showTagAssignmentSheet(
+    BuildContext context,
+    int projectId,
+    List<int> currentTagIds,
+  ) async {
     final result = await showModalBottomSheet<Set<int>>(
       context: context,
       isScrollControlled: true,
-      builder: (_) => TagSelectionSheet(
-        initialSelectedIds: currentTagIds.toSet(),
-      ),
+      builder: (_) =>
+          TagSelectionSheet(initialSelectedIds: currentTagIds.toSet()),
     );
 
     if (result != null) {
-      ref.read(projectsProvider.notifier).onEvent(AssignTagsToProject(projectId, result.toList()));
+      ref
+          .read(projectsProvider.notifier)
+          .onEvent(AssignTagsToProject(projectId, result.toList()));
     }
   }
 }
@@ -401,13 +406,13 @@ class _LargeCardView extends StatelessWidget {
   final List<Project> projects;
   final List<Tag> tags;
   final ValueChanged<int> onProjectTap;
-  final ValueChanged<int> onMoreTap;
+  final ValueChanged<int> onLongPress;
 
   const _LargeCardView({
     required this.projects,
     required this.tags,
     required this.onProjectTap,
-    required this.onMoreTap,
+    required this.onLongPress,
   });
 
   @override
@@ -423,7 +428,7 @@ class _LargeCardView extends StatelessWidget {
             project: project,
             tags: tags,
             onTap: () => onProjectTap(project.id),
-            onMoreTap: () => onMoreTap(project.id),
+            onLongPress: () => onLongPress(project.id),
           ),
         );
       },
@@ -435,13 +440,13 @@ class _LargeProjectCard extends StatelessWidget {
   final Project project;
   final List<Tag> tags;
   final VoidCallback onTap;
-  final VoidCallback onMoreTap;
+  final VoidCallback onLongPress;
 
   const _LargeProjectCard({
     required this.project,
     required this.tags,
     required this.onTap,
-    required this.onMoreTap,
+    required this.onLongPress,
   });
 
   @override
@@ -451,11 +456,10 @@ class _LargeProjectCard extends StatelessWidget {
     return Card(
       margin: EdgeInsets.zero,
       clipBehavior: Clip.antiAlias,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(14),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
       child: InkWell(
         onTap: onTap,
+        onLongPress: onLongPress,
         child: AspectRatio(
           aspectRatio: 16 / 9,
           child: Stack(
@@ -466,7 +470,8 @@ class _LargeProjectCard extends StatelessWidget {
                   ? Image.network(
                       project.imagePath!,
                       fit: BoxFit.cover,
-                      errorBuilder: (_, __, ___) => Container(color: const Color(0xFFD9D9D9)),
+                      errorBuilder: (_, __, ___) =>
+                          Container(color: const Color(0xFFD9D9D9)),
                     )
                   : Container(color: const Color(0xFFD9D9D9)),
               // 하단 정보 섹션
@@ -538,34 +543,11 @@ class _LargeProjectCard extends StatelessWidget {
                     spacing: 4,
                     runSpacing: 4,
                     children: projectTags.take(3).map((tag) {
-                      return ColoredTagChip(
-                        key: ValueKey(tag.id),
-                        tag: tag,
-                      );
+                      return ColoredTagChip(key: ValueKey(tag.id), tag: tag);
                     }).toList(),
                   ),
                 ),
 
-              // 우측 상단 더보기 버튼
-              Positioned(
-                right: 12,
-                top: 12,
-                child: Container(
-                  width: 32,
-                  height: 32,
-                  decoration: BoxDecoration(
-                    color: Colors.white.withOpacity(0.9),
-                    borderRadius: BorderRadius.circular(6.4),
-                  ),
-                  child: IconButton(
-                    icon: const Icon(Icons.more_vert),
-                    iconSize: 20,
-                    onPressed: onMoreTap,
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
-                  ),
-                ),
-              ),
               // 우측 중앙 다음 버튼
               Positioned(
                 right: 12,
@@ -577,7 +559,7 @@ class _LargeProjectCard extends StatelessWidget {
                     height: 24,
                     decoration: const BoxDecoration(
                       shape: BoxShape.circle,
-                      color: Colors.transparent, // 배경 없음
+                      color: Colors.transparent,
                     ),
                     child: IconButton(
                       icon: const Icon(Icons.arrow_forward_ios, size: 16),
@@ -601,7 +583,9 @@ class _LargeProjectCard extends StatelessWidget {
     try {
       final dynamic decoded = jsonDecode(project.tagIds!);
       if (decoded is! List) return [];
-      final tagIds = decoded.map((e) => int.tryParse(e.toString()) ?? -1).toSet();
+      final tagIds = decoded
+          .map((e) => int.tryParse(e.toString()) ?? -1)
+          .toSet();
       return tags.where((tag) => tagIds.contains(tag.id)).toList();
     } catch (_) {
       return [];
@@ -622,13 +606,13 @@ class _SmallCardView extends StatelessWidget {
   final List<Project> projects;
   final List<Tag> tags;
   final ValueChanged<int> onProjectTap;
-  final ValueChanged<int> onMoreTap;
+  final ValueChanged<int> onLongPress;
 
   const _SmallCardView({
     required this.projects,
     required this.tags,
     required this.onProjectTap,
-    required this.onMoreTap,
+    required this.onLongPress,
   });
 
   @override
@@ -648,7 +632,7 @@ class _SmallCardView extends StatelessWidget {
           project: project,
           tags: tags,
           onTap: () => onProjectTap(project.id),
-          onMoreTap: () => onMoreTap(project.id),
+          onLongPress: () => onLongPress(project.id),
         );
       },
     );
@@ -659,13 +643,13 @@ class _SmallProjectCard extends StatelessWidget {
   final Project project;
   final List<Tag> tags;
   final VoidCallback onTap;
-  final VoidCallback onMoreTap;
+  final VoidCallback onLongPress;
 
   const _SmallProjectCard({
     required this.project,
     required this.tags,
     required this.onTap,
-    required this.onMoreTap,
+    required this.onLongPress,
   });
 
   @override
@@ -675,17 +659,16 @@ class _SmallProjectCard extends StatelessWidget {
     return Card(
       margin: EdgeInsets.zero,
       clipBehavior: Clip.antiAlias,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(14),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
       child: InkWell(
         onTap: onTap,
+        onLongPress: onLongPress,
         child: Stack(
           fit: StackFit.expand,
           children: [
             // 이미지 영역
             Container(
-              color: const Color(0xFFD9D9D9), // Placeholder color from Figma
+              color: const Color(0xFFD9D9D9),
               child: project.imagePath != null
                   ? Image.network(
                       project.imagePath!,
@@ -694,7 +677,7 @@ class _SmallProjectCard extends StatelessWidget {
                     )
                   : _placeholderImage(context),
             ),
-            
+
             // 좌측 상단 태그
             if (projectTags.isNotEmpty)
               Positioned(
@@ -704,42 +687,17 @@ class _SmallProjectCard extends StatelessWidget {
                   spacing: 4,
                   runSpacing: 4,
                   children: projectTags.take(2).map((tag) {
-                    return ColoredTagChip(
-                      key: ValueKey(tag.id),
-                      tag: tag,
-                    );
+                    return ColoredTagChip(key: ValueKey(tag.id), tag: tag);
                   }).toList(),
                 ),
               ),
-
-            // 우측 상단 더보기 버튼
-            Positioned(
-              right: 8,
-              top: 8,
-              child: Container(
-                width: 32,
-                height: 32,
-                decoration: BoxDecoration(
-                  color: Colors.white.withOpacity(0.9),
-                  borderRadius: BorderRadius.circular(6.4),
-                ),
-                child: IconButton(
-                  icon: const Icon(Icons.more_vert),
-                  iconSize: 20,
-                  onPressed: onMoreTap,
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(),
-                  color: Colors.black, // Ensure icon is visible
-                ),
-              ),
-            ),
 
             // 하단 정보 바 (Project Name + Arrow)
             Positioned(
               left: 0,
               right: 0,
               bottom: 0,
-              height: 32, // Fixed height based on design (~139-107=32px)
+              height: 32,
               child: Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8.0),
                 color: Colors.black.withOpacity(0.4),
@@ -753,7 +711,7 @@ class _SmallProjectCard extends StatelessWidget {
                           fontSize: 12,
                           fontWeight: FontWeight.w400,
                           color: Colors.white,
-                          height: 1.33, // leading 16px / 12px
+                          height: 1.33,
                         ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
@@ -789,7 +747,9 @@ class _SmallProjectCard extends StatelessWidget {
     try {
       final dynamic decoded = jsonDecode(project.tagIds!);
       if (decoded is! List) return [];
-      final tagIds = decoded.map((e) => int.tryParse(e.toString()) ?? -1).toSet();
+      final tagIds = decoded
+          .map((e) => int.tryParse(e.toString()) ?? -1)
+          .toSet();
       return tags.where((tag) => tagIds.contains(tag.id)).toList();
     } catch (_) {
       return [];
@@ -805,13 +765,13 @@ class _ListView extends StatelessWidget {
   final List<Project> projects;
   final List<Tag> tags;
   final ValueChanged<int> onProjectTap;
-  final ValueChanged<int> onMoreTap;
+  final ValueChanged<int> onLongPress;
 
   const _ListView({
     required this.projects,
     required this.tags,
     required this.onProjectTap,
-    required this.onMoreTap,
+    required this.onLongPress,
   });
 
   @override
@@ -825,7 +785,7 @@ class _ListView extends StatelessWidget {
           project: project,
           tags: tags,
           onTap: () => onProjectTap(project.id),
-          onMoreTap: () => onMoreTap(project.id),
+          onLongPress: () => onLongPress(project.id),
         );
       },
     );
@@ -836,13 +796,13 @@ class _ProjectListTile extends StatelessWidget {
   final Project project;
   final List<Tag> tags;
   final VoidCallback onTap;
-  final VoidCallback onMoreTap;
+  final VoidCallback onLongPress;
 
   const _ProjectListTile({
     required this.project,
     required this.tags,
     required this.onTap,
-    required this.onMoreTap,
+    required this.onLongPress,
   });
 
   @override
@@ -854,18 +814,16 @@ class _ProjectListTile extends StatelessWidget {
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(14),
-        border: Border.all(
-          color: Colors.black.withOpacity(0.1),
-          width: 0.65,
-        ),
+        border: Border.all(color: Colors.black.withOpacity(0.1), width: 0.65),
       ),
       child: InkWell(
         onTap: onTap,
+        onLongPress: onLongPress,
         borderRadius: BorderRadius.circular(14),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center, // Align center vertically
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               // 썸네일
               Container(
@@ -881,10 +839,11 @@ class _ProjectListTile extends StatelessWidget {
                         child: Image.network(
                           project.imagePath!,
                           fit: BoxFit.cover,
-                          errorBuilder: (_, _, _) => Container(color: const Color(0xFFD9D9D9)),
+                          errorBuilder: (_, _, _) =>
+                              Container(color: const Color(0xFFD9D9D9)),
                         ),
                       )
-                    : Container(color: const Color(0xFFD9D9D9)), // Placeholder empty
+                    : Container(color: const Color(0xFFD9D9D9)),
               ),
               const SizedBox(width: 16),
               // 정보
@@ -898,8 +857,8 @@ class _ProjectListTile extends StatelessWidget {
                         fontFamily: 'Inter',
                         fontSize: 16,
                         fontWeight: FontWeight.w400,
-                        color: Color(0xFF0A0A0A), // neutral-950
-                        height: 1.5, // leading 24px / 16px
+                        color: Color(0xFF0A0A0A),
+                        height: 1.5,
                         letterSpacing: -0.31,
                       ),
                       maxLines: 1,
@@ -924,7 +883,7 @@ class _ProjectListTile extends StatelessWidget {
                                 fontSize: 14,
                                 fontWeight: FontWeight.w400,
                                 color: Color(0xFF717182),
-                                height: 1.42, // leading 20px / 14px
+                                height: 1.42,
                                 letterSpacing: -0.15,
                               ),
                             ),
@@ -956,22 +915,6 @@ class _ProjectListTile extends StatelessWidget {
                   ],
                 ),
               ),
-              // 더보기 버튼
-              SizedBox(
-                width: 40,
-                height: 40,
-                child: IconButton(
-                  icon: const Icon(Icons.more_vert),
-                  iconSize: 20,
-                  onPressed: onMoreTap,
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(),
-                  style: IconButton.styleFrom(
-                    backgroundColor: Colors.white.withOpacity(0.9), // As per design but might be invisible on white bg
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(6.4)),
-                  ),
-                ),
-              ),
             ],
           ),
         ),
@@ -991,7 +934,9 @@ class _ProjectListTile extends StatelessWidget {
     try {
       final dynamic decoded = jsonDecode(project.tagIds!);
       if (decoded is! List) return [];
-      final tagIds = decoded.map((e) => int.tryParse(e.toString()) ?? -1).toSet();
+      final tagIds = decoded
+          .map((e) => int.tryParse(e.toString()) ?? -1)
+          .toSet();
       return tags.where((tag) => tagIds.contains(tag.id)).toList();
     } catch (_) {
       return [];


### PR DESCRIPTION
- 큰 카드/작은 카드/리스트 뷰의 ⋮ 더보기 아이콘 버튼 제거
- 프로젝트 카드 롱프레스 시 바텀시트 메뉴(복사, 태그 지정) 표시
- 요구사항 문서(Req 3, 4, 5, 6, 7, 12) 현행화