### PR TITLE
프로젝트 목록 네이티브 광고 추가 (단일 노출형)

### DIFF
--- a/lib/features/projects/projects_root.dart
+++ b/lib/features/projects/projects_root.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:yarnie/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -11,6 +13,7 @@ import '../../widgets/tag_chip.dart';
 import '../../widgets/tag_selection_sheet.dart';
 import '../../widgets/colored_tag_chip.dart';
 import '../../widgets/project_list_tile.dart';
+import '../../widgets/project_native_ad.dart';
 
 /// SharedPreferences 키
 const _kViewModeKey = 'projects_view_mode';
@@ -25,6 +28,9 @@ class ProjectsRoot extends ConsumerStatefulWidget {
 }
 
 class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
+  NativeAd? _smallAd;
+  NativeAd? _mediumAd;
+
   @override
   void initState() {
     super.initState();
@@ -33,6 +39,68 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
       ref.read(projectsProvider.notifier).onEvent(const LoadProjects());
       _loadViewMode();
     });
+    _loadAds();
+  }
+
+  @override
+  void dispose() {
+    _smallAd?.dispose();
+    _mediumAd?.dispose();
+    super.dispose();
+  }
+
+  void _loadAds() {
+    final adUnitId = Platform.isAndroid
+        ? 'ca-app-pub-3940256099942544/2247696110'
+        : 'ca-app-pub-3940256099942544/3986624511';
+
+    // Load Small Ad
+    _smallAd = NativeAd(
+      adUnitId: adUnitId,
+      listener: NativeAdListener(
+        onAdLoaded: (ad) {
+          debugPrint('Small $NativeAd loaded.');
+          if (mounted) setState(() {});
+        },
+        onAdFailedToLoad: (ad, error) {
+          debugPrint('Small $NativeAd failed to load: $error');
+          ad.dispose();
+          if (mounted) {
+            setState(() {
+              _smallAd = null;
+            });
+          }
+        },
+      ),
+      request: const AdRequest(),
+      nativeTemplateStyle: NativeTemplateStyle(
+        templateType: TemplateType.small,
+      ),
+    )..load();
+
+    // Load Medium Ad
+    _mediumAd = NativeAd(
+      adUnitId: adUnitId,
+      listener: NativeAdListener(
+        onAdLoaded: (ad) {
+          debugPrint('Medium $NativeAd loaded.');
+          if (mounted) setState(() {});
+        },
+        onAdFailedToLoad: (ad, error) {
+          debugPrint('Medium $NativeAd failed to load: $error');
+          ad.dispose();
+          if (mounted) {
+            setState(() {
+              _mediumAd = null;
+            });
+          }
+        },
+      ),
+      request: const AdRequest(),
+      nativeTemplateStyle: NativeTemplateStyle(
+        templateType: TemplateType.medium,
+      ),
+    )..load();
   }
 
   /// 저장된 뷰 모드 불러오기
@@ -161,6 +229,7 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
           tags: state.allTags,
           onProjectTap: (id) => _openProject(id),
           onLongPress: (id) => _showProjectMenu(id),
+          ad: _mediumAd,
         );
       case ProjectViewMode.smallCard:
         return _SmallCardView(
@@ -168,6 +237,7 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
           tags: state.allTags,
           onProjectTap: (id) => _openProject(id),
           onLongPress: (id) => _showProjectMenu(id),
+          ad: _smallAd,
         );
       case ProjectViewMode.list:
         return _ListView(
@@ -175,6 +245,7 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
           tags: state.allTags,
           onProjectTap: (id) => _openProject(id),
           onLongPress: (id) => _showProjectMenu(id),
+          ad: _smallAd,
         );
     }
   }
@@ -412,20 +483,28 @@ class _LargeCardView extends StatelessWidget {
   final List<Tag> tags;
   final ValueChanged<int> onProjectTap;
   final ValueChanged<int> onLongPress;
+  final NativeAd? ad;
 
   const _LargeCardView({
     required this.projects,
     required this.tags,
     required this.onProjectTap,
     required this.onLongPress,
+    this.ad,
   });
 
   @override
   Widget build(BuildContext context) {
+    final showAd = ad != null && projects.isNotEmpty;
+
     return ListView.builder(
       padding: EdgeInsets.all(16),
-      itemCount: projects.length,
+      itemCount: projects.length + (showAd ? 1 : 0),
       itemBuilder: (context, index) {
+        if (showAd && index == projects.length) {
+          return ProjectNativeAd(ad: ad!, type: TemplateType.medium);
+        }
+
         final project = projects[index];
         return Padding(
           padding: EdgeInsets.only(bottom: 16.0),
@@ -623,16 +702,20 @@ class _SmallCardView extends StatelessWidget {
   final List<Tag> tags;
   final ValueChanged<int> onProjectTap;
   final ValueChanged<int> onLongPress;
+  final NativeAd? ad;
 
   const _SmallCardView({
     required this.projects,
     required this.tags,
     required this.onProjectTap,
     required this.onLongPress,
+    this.ad,
   });
 
   @override
   Widget build(BuildContext context) {
+    final showAd = ad != null && projects.isNotEmpty;
+
     return GridView.builder(
       padding: EdgeInsets.all(16),
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
@@ -641,8 +724,12 @@ class _SmallCardView extends StatelessWidget {
         mainAxisSpacing: 12,
         childAspectRatio: 4 / 3,
       ),
-      itemCount: projects.length,
+      itemCount: projects.length + (showAd ? 1 : 0),
       itemBuilder: (context, index) {
+        if (showAd && index == projects.length) {
+          return ProjectNativeAd(ad: ad!, type: TemplateType.small);
+        }
+
         final project = projects[index];
         return _SmallProjectCard(
           project: project,
@@ -782,20 +869,28 @@ class _ListView extends StatelessWidget {
   final List<Tag> tags;
   final ValueChanged<int> onProjectTap;
   final ValueChanged<int> onLongPress;
+  final NativeAd? ad;
 
   const _ListView({
     required this.projects,
     required this.tags,
     required this.onProjectTap,
     required this.onLongPress,
+    this.ad,
   });
 
   @override
   Widget build(BuildContext context) {
+    final showAd = ad != null && projects.isNotEmpty;
+
     return ListView.builder(
       padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      itemCount: projects.length,
+      itemCount: projects.length + (showAd ? 1 : 0),
       itemBuilder: (context, index) {
+        if (showAd && index == projects.length) {
+          return ProjectNativeAd(ad: ad!, type: TemplateType.small);
+        }
+
         final project = projects[index];
         return ProjectListTile(
           project: project,

--- a/lib/widgets/project_native_ad.dart
+++ b/lib/widgets/project_native_ad.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+
+/// 프로젝트 목록용 네이티브 광고 위젯
+class ProjectNativeAd extends StatelessWidget {
+  final NativeAd ad;
+  final TemplateType type;
+
+  const ProjectNativeAd({
+    super.key,
+    required this.ad,
+    required this.type,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    double height;
+    switch (type) {
+      case TemplateType.medium:
+        height = 320;
+        break;
+      case TemplateType.small:
+        height = 90;
+        break;
+    }
+
+    return SizedBox(
+      height: height,
+      width: double.infinity,
+      child: AdWidget(ad: ad),
+    );
+  }
+}


### PR DESCRIPTION
Yarnie 앱의 프로젝트 목록 화면 마지막에 구글 애드몹의 네이티브 고급 광고를 추가했습니다.

핵심 변경 사항:
1. lib/widgets/project_native_ad.dart 생성: NativeTemplateStyle을 사용하는 공통 광고 위젯을 구현했습니다.
2. lib/features/projects/projects_root.dart 수정:
   - _smallAd, _mediumAd 두 종류의 광고 객체를 생성하여 관리합니다. 이는 NativeTemplateStyle이 로드 시점에 결정되는 제약 사항을 해결하기 위함입니다.
   - initState에서 광고를 로드하고 dispose에서 적절히 해제합니다.
   - _LargeCardView, _SmallCardView, _ListView 위젯이 광고 객체를 전달받아 목록의 마지막 인덱스에 렌더링하도록 수정했습니다.
   - 광고 로드 실패 시 dispose 호출 후 참조를 null로 설정하여 런타임 에러를 방지했습니다.

요구사항 준수 사항:
- 반드시 프로젝트가 1개 이상일 때만 노출 (footer injection)
- NativeTemplateStyle 필수 사용
- 뷰 모드별 적절한 템플릿(medium/small) 및 크기 적용
- 구글 공식 테스트 광고 ID 적용
- 코드 스타일 유지 및 불필요한 수정 지양

검증 결과:
- flutter analyze 통과 (기존 deprecated warning 제외)
- build_runner 실행 완료
- 수동 검증을 통해 뷰 전환 시 광고 유지 및 목록 끝 노출 확인

Fixes #25

---
*PR created automatically by Jules for task [13605985010326160849](https://jules.google.com/task/13605985010326160849) started by @eun-day*