### PR TITLE
feat: 하단 배너 광고 공통 위젯 분리 및 프로젝트 탭 적용

### DIFF
--- a/lib/features/projects/projects_root.dart
+++ b/lib/features/projects/projects_root.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:yarnie/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +12,7 @@ import '../../widgets/tag_chip.dart';
 import '../../widgets/tag_selection_sheet.dart';
 import '../../widgets/colored_tag_chip.dart';
 import '../../widgets/project_list_tile.dart';
+import '../../widgets/common_banner_ad.dart';
 
 /// SharedPreferences 키
 const _kViewModeKey = 'projects_view_mode';
@@ -131,6 +133,11 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
             Expanded(child: _buildBody(state)),
           ],
         ),
+      ),
+      bottomNavigationBar: CommonBannerAdWidget(
+        adUnitId: Platform.isAndroid
+            ? 'ca-app-pub-3940256099942544/6300978111'
+            : 'ca-app-pub-3940256099942544/2934735716',
       ),
     );
   }

--- a/lib/project_detail_screen.dart
+++ b/lib/project_detail_screen.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:yarnie/widgets/common_banner_ad.dart';
 import 'package:drift/drift.dart' hide Column;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yarnie/db/app_db.dart';
@@ -51,57 +51,9 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
   StreamSubscription<MainCounter?>? _mainCounterSub;
   int? _prevMainValue;
 
-  BannerAd? _bannerAd;
-  bool _isAdLoaded = false;
-  AdSize? _adSize;
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _loadBannerAd();
-  }
-
-  Future<void> _loadBannerAd() async {
-    if (_bannerAd != null) return;
-
-    final Orientation orientation = MediaQuery.of(context).orientation;
-    final AnchoredAdaptiveBannerAdSize? size =
-        await AdSize.getAnchoredAdaptiveBannerAdSize(
-      orientation,
-      MediaQuery.of(context).size.width.truncate(),
-    );
-
-    if (size == null) {
-      debugPrint('Unable to get adaptive banner size.');
-      return;
-    }
-
-    _adSize = size;
-
-    _bannerAd = BannerAd(
-      adUnitId: Platform.isAndroid
-          ? 'ca-app-pub-3940256099942544/6300978111'
-          : 'ca-app-pub-3940256099942544/2934735716',
-      size: size,
-      request: const AdRequest(),
-      listener: BannerAdListener(
-        onAdLoaded: (ad) {
-          setState(() {
-            _isAdLoaded = true;
-          });
-        },
-        onAdFailedToLoad: (ad, error) {
-          ad.dispose();
-          debugPrint('BannerAd failed to load: $error');
-        },
-      ),
-    )..load();
-  }
-
   @override
   void dispose() {
     _mainCounterSub?.cancel();
-    _bannerAd?.dispose();
     super.dispose();
   }
 
@@ -413,14 +365,10 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
         backgroundColor: Theme.of(context).colorScheme.primary,
         child: Icon(Icons.add, color: Theme.of(context).colorScheme.surface),
       ),
-      bottomNavigationBar: SafeArea(
-        child: SizedBox(
-          height: _adSize?.height.toDouble() ?? AdSize.banner.height.toDouble(),
-          width: _adSize?.width.toDouble() ?? double.infinity,
-          child: _isAdLoaded && _bannerAd != null
-              ? AdWidget(ad: _bannerAd!)
-              : const SizedBox.shrink(),
-        ),
+      bottomNavigationBar: CommonBannerAdWidget(
+        adUnitId: Platform.isAndroid
+            ? 'ca-app-pub-3940256099942544/6300978111'
+            : 'ca-app-pub-3940256099942544/2934735716',
       ),
     );
   }

--- a/lib/widgets/common_banner_ad.dart
+++ b/lib/widgets/common_banner_ad.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+
+class CommonBannerAdWidget extends StatefulWidget {
+  final String adUnitId;
+
+  const CommonBannerAdWidget({
+    super.key,
+    required this.adUnitId,
+  });
+
+  @override
+  State<CommonBannerAdWidget> createState() => _CommonBannerAdWidgetState();
+}
+
+class _CommonBannerAdWidgetState extends State<CommonBannerAdWidget> {
+  BannerAd? _bannerAd;
+  bool _isAdLoaded = false;
+  AdSize? _adSize;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _loadBannerAd();
+  }
+
+  Future<void> _loadBannerAd() async {
+    if (_bannerAd != null) return;
+
+    final orientation = MediaQuery.of(context).orientation;
+    final width = MediaQuery.of(context).size.width.truncate();
+
+    final size = await AdSize.getAnchoredAdaptiveBannerAdSize(
+      orientation,
+      width,
+    );
+
+    if (size == null) {
+      debugPrint('Unable to get adaptive banner size.');
+      return;
+    }
+
+    if (!mounted) return;
+
+    _adSize = size;
+
+    _bannerAd = BannerAd(
+      adUnitId: widget.adUnitId,
+      size: size,
+      request: const AdRequest(),
+      listener: BannerAdListener(
+        onAdLoaded: (ad) {
+          if (mounted) {
+            setState(() {
+              _isAdLoaded = true;
+            });
+          }
+        },
+        onAdFailedToLoad: (ad, error) {
+          ad.dispose();
+          debugPrint('BannerAd failed to load: $error');
+          if (mounted) {
+            setState(() {
+              _bannerAd = null;
+              _isAdLoaded = false;
+            });
+          }
+        },
+      ),
+    )..load();
+  }
+
+  @override
+  void dispose() {
+    _bannerAd?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isAdLoaded || _bannerAd == null) {
+      return const SizedBox.shrink();
+    }
+
+    return SafeArea(
+      child: SizedBox(
+        width: _adSize?.width.toDouble() ?? double.infinity,
+        height: _adSize?.height.toDouble() ?? AdSize.banner.height.toDouble(),
+        child: AdWidget(ad: _bannerAd!),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
기존 `ProjectDetailScreen`에 산재되어 있던 배너 광고 로직을 `CommonBannerAdWidget`으로 캡슐화하여 재사용성을 높였습니다. 
이 위젯은 `adUnitId`를 필수로 받으며, 기기 너비에 따른 적응형 크기 계산 및 생명주기 관리를 스스로 수행합니다.
또한, 이를 `ProjectDetailScreen`과 `ProjectsRoot`의 `Scaffold.bottomNavigationBar`에 적용하여 다른 UI 요소와의 간섭 없이 안정적으로 광고가 노출되도록 구현했습니다.

Fixes #27

---
*PR created automatically by Jules for task [373461777357831593](https://jules.google.com/task/373461777357831593) started by @eun-day*