### PR TITLE
Yarnie 프리미엄 정책 및 잠금 UI 구현

### DIFF
--- a/lib/core/premium/premium_policy.dart
+++ b/lib/core/premium/premium_policy.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:yarnie/l10n/app_localizations.dart';
+import 'package:yarnie/features/my/yarnie_premium_screen.dart';
+
+class PremiumPolicy {
+  static const int maxProjects = 1;
+  static const int maxPartsPerProject = 3;
+  static const int maxCountersPerPart = 3;
+
+  static bool canCreateProject(int currentProjectCount, bool isPremium) {
+    if (isPremium) return true;
+    return currentProjectCount < maxProjects;
+  }
+
+  static bool canCreatePart(int currentPartCount, bool isPremium) {
+    if (isPremium) return true;
+    return currentPartCount < maxPartsPerProject;
+  }
+
+  static bool canCreateCounter(int currentCounterCount, bool isPremium) {
+    if (isPremium) return true;
+    return currentCounterCount < maxCountersPerPart;
+  }
+}
+
+class PremiumUIHelper {
+  static (IconData icon, Color? backgroundColor) getButtonStyle({
+    required bool isLocked,
+    required IconData defaultIcon,
+    required Color defaultBackgroundColor,
+  }) {
+    if (isLocked) {
+      return (Icons.lock, const Color(0xFF9CA3AF));
+    }
+    return (defaultIcon, defaultBackgroundColor);
+  }
+
+  static void showUpsellSnackbar(BuildContext context) {
+    ScaffoldMessenger.of(context).hideCurrentSnackBar();
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text("Yarnie 평생권을 구입하시면 무제한으로 만드실 수 있어요!"),
+        action: SnackBarAction(
+          label: "프리미엄 보기",
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const YarniePremiumScreen()),
+            );
+          },
+        ),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+}

--- a/lib/core/premium/premium_policy.dart
+++ b/lib/core/premium/premium_policy.dart
@@ -39,9 +39,9 @@ class PremiumUIHelper {
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text("Yarnie 평생권을 구입하시면 무제한으로 만드실 수 있어요!"),
+        content: Text(AppLocalizations.of(context)!.upsellSnackbarMessage),
         action: SnackBarAction(
-          label: "프리미엄 보기",
+          label: AppLocalizations.of(context)!.upsellSnackbarAction,
           onPressed: () {
             Navigator.of(context).push(
               MaterialPageRoute(builder: (_) => const YarniePremiumScreen()),

--- a/lib/db/app_db.dart
+++ b/lib/db/app_db.dart
@@ -527,6 +527,17 @@ class AppDb extends _$AppDb {
     projects,
   )..where((t) => t.id.equals(id) & t.deletedAt.isNull())).watchSingleOrNull();
 
+  /// 특정 파트의 버디 카운터 (스티치 + 섹션) 총 갯수를 스트림으로 반환
+  Stream<int> watchBuddyCountersCount(int partId) {
+    return customSelect(
+      'SELECT (SELECT COUNT(*) FROM stitch_counters WHERE part_id = ?1) + (SELECT COUNT(*) FROM section_counters WHERE part_id = ?1) as total',
+      variables: [
+        Variable.withInt(partId),
+      ],
+      readsFrom: {stitchCounters, sectionCounters},
+    ).map((row) => row.read<int>('total')).watchSingle();
+  }
+
   /// 프로젝트 휴지통 이동 (소프트 딜리트)
   Future<void> softDeleteProject(int projectId) async {
     final now = DateTime.now().toUtc();

--- a/lib/features/home/home_root.dart
+++ b/lib/features/home/home_root.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yarnie/l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:yarnie/db/app_db.dart';
@@ -9,6 +11,10 @@ import 'package:yarnie/new_project_screen.dart';
 import 'package:yarnie/project_detail_screen.dart';
 import 'package:yarnie/features/home/user_guide_screen.dart';
 import 'package:yarnie/theme/text_styles.dart';
+import 'package:yarnie/widgets/common_banner_ad.dart';
+import 'package:yarnie/widgets/ad_visibility_wrapper.dart';
+import 'package:yarnie/core/providers/premium_provider.dart';
+import 'package:yarnie/core/premium/premium_policy.dart';
 
 const _kGuideCardDismissedKey = 'home_guide_card_dismissed';
 
@@ -29,17 +35,17 @@ List<({String emoji, String text})> _getKnittingTips(BuildContext context) {
   ];
 }
 
-class HomeRoot extends StatefulWidget {
+class HomeRoot extends ConsumerStatefulWidget {
   final ScrollController? controller;
   final String title;
 
   const HomeRoot({super.key, this.controller, this.title = 'Yarnie'});
 
   @override
-  State<HomeRoot> createState() => _HomeRootState();
+  ConsumerState<HomeRoot> createState() => _HomeRootState();
 }
 
-class _HomeRootState extends State<HomeRoot> {
+class _HomeRootState extends ConsumerState<HomeRoot> {
   bool _showGuideCard = false; // SharedPreferences 로드 전까지 숨김
   int _currentTipPage = 0;
   late final PageController _tipPageController;
@@ -119,6 +125,15 @@ class _HomeRootState extends State<HomeRoot> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      bottomNavigationBar: ref.watch(premiumProvider)
+          ? null
+          : AdVisibilityWrapper(
+              child: CommonBannerAdWidget(
+                adUnitId: Platform.isAndroid
+                    ? 'ca-app-pub-3940256099942544/6300978111'
+                    : 'ca-app-pub-3940256099942544/2934735716',
+              ),
+            ),
       body: SafeArea(
         child: SingleChildScrollView(
           controller: widget.controller,
@@ -146,13 +161,19 @@ class _HomeRootState extends State<HomeRoot> {
                 )
               else
                 _NewProjectCard(
+                  projectCount: _projects.length,
                   onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => const NewProjectScreen(),
-                      ),
-                    );
+                    final isPremium = ref.read(premiumProvider);
+                    if (PremiumPolicy.canCreateProject(_projects.length, isPremium)) {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const NewProjectScreen(),
+                        ),
+                      );
+                    } else {
+                      PremiumUIHelper.showUpsellSnackbar(context);
+                    }
                   },
                 ),
               const SizedBox(height: 16),
@@ -217,12 +238,20 @@ class _WelcomeMessage extends StatelessWidget {
 // 2a. NewProjectCard (신규 사용자)
 // ─────────────────────────────────────────────────────────────────────────────
 
-class _NewProjectCard extends StatelessWidget {
+class _NewProjectCard extends ConsumerWidget {
+  final int projectCount;
   final VoidCallback onTap;
-  const _NewProjectCard({required this.onTap});
+  const _NewProjectCard({required this.projectCount, required this.onTap});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isPremium = ref.watch(premiumProvider);
+    final isLocked = !PremiumPolicy.canCreateProject(projectCount, isPremium);
+    final buttonStyle = PremiumUIHelper.getButtonStyle(
+      isLocked: isLocked,
+      defaultIcon: Icons.bolt,
+      defaultBackgroundColor: Theme.of(context).colorScheme.primary,
+    );
     return Container(
       width: double.infinity,
       padding: EdgeInsets.all(24),
@@ -270,7 +299,7 @@ class _NewProjectCard extends StatelessWidget {
             height: 36,
             child: FilledButton.icon(
               onPressed: onTap,
-              icon: const Icon(Icons.bolt, size: 16),
+              icon: Icon(buttonStyle.$1, size: 16),
               label: Text(
                 AppLocalizations.of(context)!.createNewProject,
                 style: TextStyle(
@@ -281,7 +310,7 @@ class _NewProjectCard extends StatelessWidget {
                 ),
               ),
               style: FilledButton.styleFrom(
-                backgroundColor: Theme.of(context).colorScheme.primary,
+                backgroundColor: buttonStyle.$2,
                 foregroundColor: Theme.of(context).colorScheme.surface,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(8),

--- a/lib/features/my/my_root.dart
+++ b/lib/features/my/my_root.dart
@@ -9,6 +9,7 @@ import 'package:yarnie/features/home/user_guide_screen.dart';
 import 'package:yarnie/features/my/widgets/app_info_sheet.dart';
 import 'package:yarnie/features/my/yarnie_premium_screen.dart';
 import 'package:yarnie/core/providers/theme_provider.dart';
+import 'package:yarnie/core/providers/premium_provider.dart';
 
 class MyRoot extends ConsumerStatefulWidget {
   final ScrollController? controller;
@@ -30,7 +31,21 @@ class _MyRootState extends ConsumerState<MyRoot> {
       slivers: [
         SliverAppBar(
           pinned: true,
-          title: Text(AppLocalizations.of(context)!.my),
+          title: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(AppLocalizations.of(context)!.my),
+              if (ref.watch(premiumProvider))
+                Text(
+                  "Premium Member 👑",
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ),
+            ],
+          ),
         ),
         SliverPadding(
           padding:  const EdgeInsets.only(top: 24, left: 16, right: 16, bottom: 40),

--- a/lib/features/my/my_root.dart
+++ b/lib/features/my/my_root.dart
@@ -31,19 +31,22 @@ class _MyRootState extends ConsumerState<MyRoot> {
       slivers: [
         SliverAppBar(
           pinned: true,
+          centerTitle: true,
           title: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Text(AppLocalizations.of(context)!.my),
-              if (ref.watch(premiumProvider))
+              if (ref.watch(premiumProvider)) ...[
+                const SizedBox(height: 4),
                 Text(
                   "Premium Member 👑",
                   style: TextStyle(
-                    fontSize: 12,
+                    fontSize: 14,
                     fontWeight: FontWeight.bold,
-                    color: Theme.of(context).colorScheme.primary,
+                    color: const Color(0xFF6FB96F),
                   ),
                 ),
+              ],
             ],
           ),
         ),

--- a/lib/features/projects/projects_root.dart
+++ b/lib/features/projects/projects_root.dart
@@ -94,7 +94,7 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
                 final buttonStyle = PremiumUIHelper.getButtonStyle(
                   isLocked: isLocked,
                   defaultIcon: Icons.add,
-                  defaultBackgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+                  defaultBackgroundColor: const Color(0xFF637069),
                 );
 
                 return FilledButton.tonalIcon(

--- a/lib/features/projects/projects_root.dart
+++ b/lib/features/projects/projects_root.dart
@@ -13,6 +13,9 @@ import '../../widgets/tag_selection_sheet.dart';
 import '../../widgets/colored_tag_chip.dart';
 import '../../widgets/project_list_tile.dart';
 import '../../widgets/common_banner_ad.dart';
+import '../../widgets/ad_visibility_wrapper.dart';
+import '../../core/providers/premium_provider.dart';
+import '../../core/premium/premium_policy.dart';
 
 /// SharedPreferences 키
 const _kViewModeKey = 'projects_view_mode';
@@ -84,18 +87,37 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
         actions: [
           Padding(
             padding: EdgeInsets.only(right: 8),
-            child: FilledButton.tonalIcon(
-              onPressed: () => Navigator.of(context).push(
-                MaterialPageRoute(builder: (_) => const NewProjectScreen()),
-              ),
-              icon: const Icon(Icons.add, size: 20),
-              label: Text(AppLocalizations.of(context)!.createNewProject),
-              style: FilledButton.styleFrom(
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-              ),
+            child: Consumer(
+              builder: (context, ref, _) {
+                final isPremium = ref.watch(premiumProvider);
+                final isLocked = !PremiumPolicy.canCreateProject(state.allProjects.length, isPremium);
+                final buttonStyle = PremiumUIHelper.getButtonStyle(
+                  isLocked: isLocked,
+                  defaultIcon: Icons.add,
+                  defaultBackgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+                );
+
+                return FilledButton.tonalIcon(
+                  onPressed: () {
+                    if (!isLocked) {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(builder: (_) => const NewProjectScreen()),
+                      );
+                    } else {
+                      PremiumUIHelper.showUpsellSnackbar(context);
+                    }
+                  },
+                  icon: Icon(buttonStyle.$1, size: 20),
+                  label: Text(AppLocalizations.of(context)!.createNewProject),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: buttonStyle.$2,
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                );
+              },
             ),
           ),
         ],
@@ -134,11 +156,15 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
           ],
         ),
       ),
-      bottomNavigationBar: CommonBannerAdWidget(
-        adUnitId: Platform.isAndroid
-            ? 'ca-app-pub-3940256099942544/6300978111'
-            : 'ca-app-pub-3940256099942544/2934735716',
-      ),
+      bottomNavigationBar: ref.watch(premiumProvider)
+          ? null
+          : AdVisibilityWrapper(
+              child: CommonBannerAdWidget(
+                adUnitId: Platform.isAndroid
+                    ? 'ca-app-pub-3940256099942544/6300978111'
+                    : 'ca-app-pub-3940256099942544/2934735716',
+              ),
+            ),
     );
   }
 
@@ -819,11 +845,20 @@ class _ListView extends StatelessWidget {
 // 빈 상태 뷰
 // ============================================================
 
-class _EmptyView extends StatelessWidget {
+class _EmptyView extends ConsumerWidget {
   const _EmptyView();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(projectsProvider);
+    final isPremium = ref.watch(premiumProvider);
+    final isLocked = !PremiumPolicy.canCreateProject(state.allProjects.length, isPremium);
+    final buttonStyle = PremiumUIHelper.getButtonStyle(
+      isLocked: isLocked,
+      defaultIcon: Icons.add,
+      defaultBackgroundColor: Theme.of(context).colorScheme.primary,
+    );
+
     return Center(
       child: Padding(
         padding: EdgeInsets.all(24),
@@ -844,12 +879,19 @@ class _EmptyView extends StatelessWidget {
             const SizedBox(height: 16),
             FilledButton.icon(
               onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(builder: (_) => const NewProjectScreen()),
-                );
+                if (!isLocked) {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const NewProjectScreen()),
+                  );
+                } else {
+                  PremiumUIHelper.showUpsellSnackbar(context);
+                }
               },
-              icon: const Icon(Icons.add),
+              icon: Icon(buttonStyle.$1),
               label: Text(AppLocalizations.of(context)!.createProject),
+              style: FilledButton.styleFrom(
+                backgroundColor: buttonStyle.$2,
+              ),
             ),
           ],
         ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -467,5 +467,7 @@
   "premiumPurchaseFailed": "Purchase failed. Please try again.",
   "premiumRestoreSuccess": "Purchases restored successfully.",
   "premiumRestoreNoHistory": "No purchase history found to restore.",
-  "premiumNetworkError": "A network error occurred. Please check your connection."
+  "premiumNetworkError": "A network error occurred. Please check your connection.",
+  "upsellSnackbarMessage": "Purchase Yarnie Premium to create unlimited projects!",
+  "upsellSnackbarAction": "View Premium"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -468,5 +468,7 @@
   "premiumPurchaseFailed": "결제에 실패했습니다. 다시 시도해주세요.",
   "premiumRestoreSuccess": "구매 내역이 성공적으로 복원되었습니다.",
   "premiumRestoreNoHistory": "복원할 구매 내역이 없습니다.",
-  "premiumNetworkError": "네트워크 오류가 발생했습니다. 연결 상태를 확인해주세요."
+  "premiumNetworkError": "네트워크 오류가 발생했습니다. 연결 상태를 확인해주세요.",
+  "upsellSnackbarMessage": "Yarnie 평생권을 구입하시면 무제한으로 만드실 수 있어요!",
+  "upsellSnackbarAction": "프리미엄 보기"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2905,6 +2905,18 @@ abstract class AppLocalizations {
   /// In ko, this message translates to:
   /// **'네트워크 오류가 발생했습니다. 연결 상태를 확인해주세요.'**
   String get premiumNetworkError;
+
+  /// No description provided for @upsellSnackbarMessage.
+  ///
+  /// In ko, this message translates to:
+  /// **'Yarnie 평생권을 구입하시면 무제한으로 만드실 수 있어요!'**
+  String get upsellSnackbarMessage;
+
+  /// No description provided for @upsellSnackbarAction.
+  ///
+  /// In ko, this message translates to:
+  /// **'프리미엄 보기'**
+  String get upsellSnackbarAction;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1546,4 +1546,11 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get premiumNetworkError =>
       'A network error occurred. Please check your connection.';
+
+  @override
+  String get upsellSnackbarMessage =>
+      'Purchase Yarnie Premium to create unlimited projects!';
+
+  @override
+  String get upsellSnackbarAction => 'View Premium';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1493,4 +1493,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get premiumNetworkError => '네트워크 오류가 발생했습니다. 연결 상태를 확인해주세요.';
+
+  @override
+  String get upsellSnackbarMessage => 'Yarnie 평생권을 구입하시면 무제한으로 만드실 수 있어요!';
+
+  @override
+  String get upsellSnackbarAction => '프리미엄 보기';
 }

--- a/lib/modules/projects/application/part_counters_event.dart
+++ b/lib/modules/projects/application/part_counters_event.dart
@@ -1,0 +1,11 @@
+sealed class PartCountersEvent {}
+
+class LoadPartCountersCount extends PartCountersEvent {
+  final int partId;
+  LoadPartCountersCount(this.partId);
+}
+
+class TotalCountUpdated extends PartCountersEvent {
+  final int count;
+  TotalCountUpdated(this.count);
+}

--- a/lib/modules/projects/application/part_counters_notifier.dart
+++ b/lib/modules/projects/application/part_counters_notifier.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../db/di.dart';
+import 'part_counters_state.dart';
+import 'part_counters_event.dart';
+
+class PartCountersNotifier extends Notifier<PartCountersState> {
+  StreamSubscription? _countSubscription;
+
+  @override
+  PartCountersState build() {
+    ref.onDispose(() {
+      _countSubscription?.cancel();
+    });
+    return const PartCountersState();
+  }
+
+  void onEvent(PartCountersEvent event) {
+    switch (event) {
+      case LoadPartCountersCount(:final partId):
+        _loadCount(partId);
+      case TotalCountUpdated(:final count):
+        state = state.copyWith(
+          totalCount: count,
+          isLoading: false,
+          clearError: true,
+        );
+    }
+  }
+
+  void _loadCount(int partId) {
+    if (state.isLoading) return;
+    state = state.copyWith(isLoading: true, clearError: true);
+
+    _countSubscription?.cancel();
+    _countSubscription = appDb
+        .watchBuddyCountersCount(partId)
+        .listen(
+          (count) => onEvent(TotalCountUpdated(count)),
+          onError: (e, st) => state = state.copyWith(
+            error: '카운터 수 로드 실패: $e',
+            isLoading: false,
+          ),
+        );
+  }
+}
+
+final partCountersProvider =
+    NotifierProvider.autoDispose<PartCountersNotifier, PartCountersState>(
+      PartCountersNotifier.new,
+    );

--- a/lib/modules/projects/application/part_counters_state.dart
+++ b/lib/modules/projects/application/part_counters_state.dart
@@ -1,0 +1,24 @@
+class PartCountersState {
+  final int totalCount;
+  final bool isLoading;
+  final String? error;
+
+  const PartCountersState({
+    this.totalCount = 0,
+    this.isLoading = false,
+    this.error,
+  });
+
+  PartCountersState copyWith({
+    int? totalCount,
+    bool? isLoading,
+    String? error,
+    bool clearError = false,
+  }) {
+    return PartCountersState(
+      totalCount: totalCount ?? this.totalCount,
+      isLoading: isLoading ?? this.isLoading,
+      error: clearError ? null : (error ?? this.error),
+    );
+  }
+}

--- a/lib/project_detail_screen.dart
+++ b/lib/project_detail_screen.dart
@@ -5,6 +5,9 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:yarnie/widgets/common_banner_ad.dart';
+import 'package:yarnie/widgets/ad_visibility_wrapper.dart';
+import 'package:yarnie/core/providers/premium_provider.dart';
+import 'package:yarnie/core/premium/premium_policy.dart';
 import 'package:drift/drift.dart' hide Column;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yarnie/db/app_db.dart';
@@ -230,8 +233,37 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
         ),
       ),
       // FAB for adding counters
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
+      floatingActionButton: Consumer(
+        builder: (context, ref, _) {
+          final isPremium = ref.watch(premiumProvider);
+          final counterCountStream = _selectedPartId == null
+              ? Stream<int>.value(0)
+              : appDb.customSelect(
+                  'SELECT (SELECT COUNT(*) FROM stitch_counters WHERE part_id = ?) + (SELECT COUNT(*) FROM section_counters WHERE part_id = ?) as total',
+                  variables: [
+                    Variable.withInt(_selectedPartId!),
+                    Variable.withInt(_selectedPartId!),
+                  ],
+                  readsFrom: {appDb.stitchCounters, appDb.sectionCounters},
+                ).map((row) => row.read<int>('total')).watchSingle();
+
+          return StreamBuilder<int>(
+            stream: counterCountStream,
+            builder: (context, snapshot) {
+              final counterCount = snapshot.data ?? 0;
+              final isLocked = !PremiumPolicy.canCreateCounter(counterCount, isPremium);
+              final buttonStyle = PremiumUIHelper.getButtonStyle(
+                isLocked: isLocked,
+                defaultIcon: Icons.add,
+                defaultBackgroundColor: Theme.of(context).colorScheme.primary,
+              );
+
+              return FloatingActionButton(
+                onPressed: () {
+                  if (isLocked) {
+                    PremiumUIHelper.showUpsellSnackbar(context);
+                    return;
+                  }
           showDialog(
             context: context,
             barrierColor:
@@ -362,14 +394,22 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
             },
           );
         },
-        backgroundColor: Theme.of(context).colorScheme.primary,
-        child: Icon(Icons.add, color: Theme.of(context).colorScheme.surface),
+                backgroundColor: buttonStyle.$2,
+                child: Icon(buttonStyle.$1, color: Theme.of(context).colorScheme.surface),
+              );
+            },
+          );
+        },
       ),
-      bottomNavigationBar: CommonBannerAdWidget(
-        adUnitId: Platform.isAndroid
-            ? 'ca-app-pub-3940256099942544/6300978111'
-            : 'ca-app-pub-3940256099942544/2934735716',
-      ),
+      bottomNavigationBar: ref.watch(premiumProvider)
+          ? null
+          : AdVisibilityWrapper(
+              child: CommonBannerAdWidget(
+                adUnitId: Platform.isAndroid
+                    ? 'ca-app-pub-3940256099942544/6300978111'
+                    : 'ca-app-pub-3940256099942544/2934735716',
+              ),
+            ),
     );
   }
 
@@ -700,31 +740,49 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
                   top: 12,
                   bottom: 12,
                 ),
-                child: GestureDetector(
-                  onTap: () => _showAddPartDialog(context, project.id),
-                  child: Container(
-                    padding: EdgeInsets.symmetric(horizontal: 12),
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.primary,
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                    alignment: Alignment.center,
-                    child: Row(
-                      children: [
-                        Icon(Icons.add, color: Theme.of(context).colorScheme.surface, size: 16),
-                        SizedBox(width: 4),
-                        Text(
-                          l10n.newPart,
-                          style: TextStyle(
-                            color: Theme.of(context).colorScheme.surface,
-                            fontSize: 16,
-                            fontWeight: FontWeight.w400,
-                            letterSpacing: -0.31,
-                          ),
+                child: Consumer(
+                  builder: (context, ref, _) {
+                    final isPremium = ref.watch(premiumProvider);
+                    final isLocked = !PremiumPolicy.canCreatePart(parts.length, isPremium);
+                    final buttonStyle = PremiumUIHelper.getButtonStyle(
+                      isLocked: isLocked,
+                      defaultIcon: Icons.add,
+                      defaultBackgroundColor: Theme.of(context).colorScheme.primary,
+                    );
+
+                    return GestureDetector(
+                      onTap: () {
+                        if (!isLocked) {
+                          _showAddPartDialog(context, project.id);
+                        } else {
+                          PremiumUIHelper.showUpsellSnackbar(context);
+                        }
+                      },
+                      child: Container(
+                        padding: EdgeInsets.symmetric(horizontal: 12),
+                        decoration: BoxDecoration(
+                          color: buttonStyle.$2,
+                          borderRadius: BorderRadius.circular(10),
                         ),
-                      ],
-                    ),
-                  ),
+                        alignment: Alignment.center,
+                        child: Row(
+                          children: [
+                            Icon(buttonStyle.$1, color: Theme.of(context).colorScheme.surface, size: 16),
+                            SizedBox(width: 4),
+                            Text(
+                              l10n.newPart,
+                              style: TextStyle(
+                                color: Theme.of(context).colorScheme.surface,
+                                fontSize: 16,
+                                fontWeight: FontWeight.w400,
+                                letterSpacing: -0.31,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  }
                 ),
               ),
 

--- a/lib/project_detail_screen.dart
+++ b/lib/project_detail_screen.dart
@@ -38,6 +38,8 @@ import 'package:yarnie/core/providers/settings_provider.dart';
 import 'package:yarnie/common/haptic_helper.dart';
 import 'package:yarnie/modules/projects/application/projects_notifier.dart';
 import 'package:yarnie/modules/projects/application/projects_event.dart';
+import 'package:yarnie/modules/projects/application/part_counters_notifier.dart';
+import 'package:yarnie/modules/projects/application/part_counters_event.dart';
 
 class ProjectDetailScreen extends ConsumerStatefulWidget {
   final int projectId;
@@ -63,6 +65,8 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
   void _listenToMainCounter(int partId) {
     _mainCounterSub?.cancel();
     _prevMainValue = null; // Reset for new part
+
+    ref.read(partCountersProvider.notifier).onEvent(LoadPartCountersCount(partId));
 
     _mainCounterSub =
         (appDb.select(appDb.mainCounters)
@@ -236,22 +240,9 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
       floatingActionButton: Consumer(
         builder: (context, ref, _) {
           final isPremium = ref.watch(premiumProvider);
-          final counterCountStream = _selectedPartId == null
-              ? Stream<int>.value(0)
-              : appDb.customSelect(
-                  'SELECT (SELECT COUNT(*) FROM stitch_counters WHERE part_id = ?) + (SELECT COUNT(*) FROM section_counters WHERE part_id = ?) as total',
-                  variables: [
-                    Variable.withInt(_selectedPartId!),
-                    Variable.withInt(_selectedPartId!),
-                  ],
-                  readsFrom: {appDb.stitchCounters, appDb.sectionCounters},
-                ).map((row) => row.read<int>('total')).watchSingle();
-
-          return StreamBuilder<int>(
-            stream: counterCountStream,
-            builder: (context, snapshot) {
-              final counterCount = snapshot.data ?? 0;
-              final isLocked = !PremiumPolicy.canCreateCounter(counterCount, isPremium);
+          final partCountersState = ref.watch(partCountersProvider);
+          final counterCount = partCountersState.totalCount;
+          final isLocked = !PremiumPolicy.canCreateCounter(counterCount, isPremium);
               final buttonStyle = PremiumUIHelper.getButtonStyle(
                 isLocked: isLocked,
                 defaultIcon: Icons.add,
@@ -397,8 +388,6 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
                 backgroundColor: buttonStyle.$2,
                 child: Icon(buttonStyle.$1, color: Theme.of(context).colorScheme.surface),
               );
-            },
-          );
         },
       ),
       bottomNavigationBar: ref.watch(premiumProvider)

--- a/lib/root/root_scaffold.dart
+++ b/lib/root/root_scaffold.dart
@@ -1,19 +1,21 @@
 import 'dart:io' show Platform;
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yarnie/l10n/app_localizations.dart';
 import 'package:yarnie/widgets/exit_confirm_dialog.dart';
+import 'package:yarnie/core/providers/premium_provider.dart';
 import '../../features/home/home_root.dart';
 import '../../features/projects/projects_root.dart';
 import '../../features/my/my_root.dart';
 
-class RootScaffold extends StatefulWidget {
+class RootScaffold extends ConsumerStatefulWidget {
   const RootScaffold({super.key});
   @override
-  State<RootScaffold> createState() => _RootScaffoldState();
+  ConsumerState<RootScaffold> createState() => _RootScaffoldState();
 }
 
-class _RootScaffoldState extends State<RootScaffold> {
+class _RootScaffoldState extends ConsumerState<RootScaffold> {
   final _bucket = PageStorageBucket();
   int _index = 0;
 
@@ -52,6 +54,12 @@ Future<void> _handleBack(bool didPop, Object? result) async {
 
     // iOS에선 조용히 무시
     if (!Platform.isAndroid) return;
+
+    final isPremium = ref.read(premiumProvider);
+    if (isPremium) {
+      SystemNavigator.pop();
+      return;
+    }
 
     // Android: 앱 종료 확인 팝업 노출
     final shouldExit = await showDialog<bool>(

--- a/lib/widgets/ad_visibility_wrapper.dart
+++ b/lib/widgets/ad_visibility_wrapper.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yarnie/core/providers/premium_provider.dart';
+
+class AdVisibilityWrapper extends ConsumerWidget {
+  final Widget child;
+
+  const AdVisibilityWrapper({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isPremium = ref.watch(premiumProvider);
+
+    if (isPremium) {
+      return const SizedBox.shrink();
+    }
+
+    return child;
+  }
+}

--- a/lib/widgets/exit_confirm_dialog.dart
+++ b/lib/widgets/exit_confirm_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:yarnie/l10n/app_localizations.dart';
+import 'package:yarnie/widgets/ad_visibility_wrapper.dart';
 
 class ExitConfirmDialog extends StatefulWidget {
   const ExitConfirmDialog({super.key});
@@ -89,17 +90,19 @@ class _ExitConfirmDialogState extends State<ExitConfirmDialog> {
             ),
             const SizedBox(height: 16),
             // 광고 영역 (300x250)
-            SizedBox(
-              width: 300,
-              height: 250,
-              child: _isAdLoaded
-                  ? AdWidget(ad: _bannerAd!)
-                  : Container(
-                      color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.1),
-                      child: const Center(
-                        child: CircularProgressIndicator(),
+            AdVisibilityWrapper(
+              child: SizedBox(
+                width: 300,
+                height: 250,
+                child: _isAdLoaded
+                    ? AdWidget(ad: _bannerAd!)
+                    : Container(
+                        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.1),
+                        child: const Center(
+                          child: CircularProgressIndicator(),
+                        ),
                       ),
-                    ),
+              ),
             ),
             const SizedBox(height: 20),
             // Buttons


### PR DESCRIPTION
RevenueCat의 프리미엄 상태와 연동하여 '1-3-3 프리미엄 정책' 및 광고 제어 아키텍처를 구현했습니다.

### 주요 변경 사항

1. **프리미엄 정책 구현 (`lib/core/premium/premium_policy.dart`)**
   - 무료 버전 제한: 프로젝트 최대 1개, 프로젝트당 Part 최대 3개, Part당 카운터 최대 3개.
   - `PremiumPolicy` 클래스를 통해 생성 가능 여부 판단 로직을 캡슐화했습니다.

2. **광고 제어 아키텍처 (`lib/widgets/ad_visibility_wrapper.dart`)**
   - `AdVisibilityWrapper` 커스텀 위젯을 구현하여 `isPremium` 상태에 따라 광고 위젯을 노출하거나 제거합니다.
   - 홈 화면, 프로젝트 목록, 상세 화면, 종료 팝업의 모든 광고 배너에 적용했습니다.

3. **상태 기반 잠금 UI (`lib/core/premium/premium_policy.dart`)**
   - `PremiumUIHelper.getButtonStyle`을 통해 잠금 상태에 따른 스타일(Icons.lock, Gray 400)을 제공합니다.
   - '새 프로젝트 추가', '새 파트 추가', '카운터 추가 FAB' 버튼에 적용했습니다.

4. **잠금 인터랙션 및 업셀**
   - 잠금 상태의 버튼 클릭 시 "Yarnie 평생권을 구입하시면 무제한으로 만드실 수 있어요!" 스낵바를 노출합니다.
   - 스낵바 내 [프리미엄 보기] 버튼 클릭 시 프리미엄 결제 안내 화면으로 이동합니다.

5. **레이아웃 및 앱 종료 로직 개선**
   - 프리미엄 사용자일 경우 `Scaffold`의 `bottomNavigationBar`를 `null`로 설정하여 광고 공간을 회수하고 리스트가 화면 끝까지 차도록 조정했습니다.
   - 안드로이드 뒤로가기 버튼 시 프리미엄 사용자는 확인 팝업 없이 즉시 앱을 종료하도록 수정했습니다.

6. **My 탭 개선**
   - 프리미엄 사용자일 경우 My 탭 타이틀 아래에 "Premium Member 👑" 텍스트를 추가했습니다.

### 검증 결과
- `flutter pub get` 및 `build_runner` 정상 완료.
- `flutter analyze` 결과 에러 및 경고 없음.
- `flutter test`를 통한 비즈니스 로직 및 통합 테스트 검증 완료.

Fixes #35

---
*PR created automatically by Jules for task [8921570671125463664](https://jules.google.com/task/8921570671125463664) started by @eun-day*