### PR TITLE
refactor: 프로젝트 이미지 저장 및 로드 방식 개선 (상대 경로 적용)

### DIFF
--- a/lib/core/utils/project_image_utils.dart
+++ b/lib/core/utils/project_image_utils.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+/// 프로젝트 이미지 경로 관리 유틸리티
+///
+/// DB에는 상대 경로(예: 'project_images/123456.jpg')만 저장하고,
+/// 런타임에 Documents 디렉토리 경로를 조합하여 절대 경로를 생성합니다.
+/// 이렇게 하면 앱 재설치 시 샌드박스 UUID가 변경되어도 이미지를 찾을 수 있습니다.
+class ProjectImageUtils {
+  static const _imageSubDir = 'project_images';
+
+  /// 앱 Documents 디렉토리 경로 (캐시)
+  static String? _cachedDocPath;
+
+  /// Documents 디렉토리 경로를 가져옵니다 (캐시 사용)
+  static Future<String> _getDocPath() async {
+    if (_cachedDocPath != null) return _cachedDocPath!;
+    final appDir = await getApplicationDocumentsDirectory();
+    _cachedDocPath = appDir.path;
+    return _cachedDocPath!;
+  }
+
+  /// 상대 경로 → 절대 경로 변환
+  /// DB에 저장된 상대 경로를 실제 파일 시스템 절대 경로로 변환합니다.
+  /// null이면 null 반환.
+  static Future<String?> toAbsolutePath(String? relativePath) async {
+    if (relativePath == null) return null;
+    // 이미 절대 경로인 경우 (하위 호환)
+    if (relativePath.startsWith('/')) return relativePath;
+    final docPath = await _getDocPath();
+    return p.join(docPath, relativePath);
+  }
+
+  /// 이미지를 영구 저장소로 복사하고 **상대 경로**를 반환
+  ///
+  /// [sourcePath]: image_picker가 반환한 임시 파일 경로
+  /// 반환: DB에 저장할 상대 경로 (예: 'project_images/1234567890.jpg')
+  static Future<String> persistImage(String sourcePath) async {
+    final docPath = await _getDocPath();
+    final imageDir = Directory(p.join(docPath, _imageSubDir));
+
+    // 이미 영구 저장소에 있는 파일이면 상대 경로로 변환하여 반환
+    if (sourcePath.startsWith(imageDir.path)) {
+      return p.relative(sourcePath, from: docPath);
+    }
+
+    // 디렉토리 생성
+    if (!await imageDir.exists()) {
+      await imageDir.create(recursive: true);
+    }
+
+    // 고유 파일명 생성 (타임스탬프 + 확장자)
+    final ext = p.extension(sourcePath).isNotEmpty
+        ? p.extension(sourcePath)
+        : '.jpg';
+    final fileName = '${DateTime.now().millisecondsSinceEpoch}$ext';
+    final destPath = p.join(imageDir.path, fileName);
+
+    // 복사
+    final sourceFile = File(sourcePath);
+    await sourceFile.copy(destPath);
+
+    // 상대 경로 반환
+    return p.join(_imageSubDir, fileName);
+  }
+
+  /// 기존 이미지 파일 삭제 (상대 경로 또는 절대 경로 모두 처리)
+  static Future<void> deleteImage(String? imagePath) async {
+    if (imagePath == null) return;
+    try {
+      String absPath;
+      if (imagePath.startsWith('/')) {
+        absPath = imagePath;
+      } else {
+        final docPath = await _getDocPath();
+        absPath = p.join(docPath, imagePath);
+      }
+      final file = File(absPath);
+      if (await file.exists()) await file.delete();
+    } catch (_) {}
+  }
+}

--- a/lib/features/projects/projects_root.dart
+++ b/lib/features/projects/projects_root.dart
@@ -12,6 +12,7 @@ import '../../widgets/tag_chip.dart';
 import '../../widgets/tag_selection_sheet.dart';
 import '../../widgets/colored_tag_chip.dart';
 import '../../widgets/project_list_tile.dart';
+import '../../widgets/project_image.dart';
 import '../../widgets/common_banner_ad.dart';
 import '../../widgets/ad_visibility_wrapper.dart';
 import '../../core/providers/premium_provider.dart';
@@ -505,11 +506,9 @@ class _LargeProjectCard extends StatelessWidget {
             children: [
               // 배경 이미지
               project.imagePath != null
-                  ? Image.network(
-                      project.imagePath!,
+                  ? ProjectImage(
+                      imagePath: project.imagePath,
                       fit: BoxFit.cover,
-                      errorBuilder: (_, __, ___) =>
-                          Container(color: const Color(0xFFD9D9D9)),
                     )
                   : Container(color: const Color(0xFFD9D9D9)),
               // 하단 정보 섹션
@@ -719,10 +718,10 @@ class _SmallProjectCard extends StatelessWidget {
             Container(
               color: const Color(0xFFD9D9D9),
               child: project.imagePath != null
-                  ? Image.network(
-                      project.imagePath!,
+                  ? ProjectImage(
+                      imagePath: project.imagePath,
                       fit: BoxFit.cover,
-                      errorBuilder: (_, _, _) => _placeholderImage(context),
+                      placeholder: _placeholderImage(context),
                     )
                   : _placeholderImage(context),
             ),

--- a/lib/modules/projects/application/project_form_notifier.dart
+++ b/lib/modules/projects/application/project_form_notifier.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/utils/project_image_utils.dart';
+
 import '../../../../db/di.dart'; // appDb 인스턴스
 import 'projects_notifier.dart'; // ProjectsNotifier에 프로젝트 생성/업데이트 이벤트를 전달하기 위함
 import 'projects_event.dart'; // CreateProject, UpdateProject 이벤트
@@ -168,6 +170,12 @@ class ProjectFormNotifier extends Notifier<ProjectFormState> {
     state = state.copyWith(isSaving: true, error: null);
 
     try {
+      // 이미지를 영구 저장소로 복사
+      final persistedImagePath = await _persistImage(
+        newPath: state.imagePath,
+        oldPath: state.initialProject?.imagePath,
+      );
+
       final projectsNotifier = ref.read(projectsProvider.notifier);
       if (state.isEditMode && state.initialProjectId != null) {
         // 프로젝트 수정
@@ -181,7 +189,7 @@ class ProjectFormNotifier extends Notifier<ProjectFormState> {
             memo: state.memo,
             gaugeStitches: state.gaugeStitches,
             gaugeRows: state.gaugeRows,
-            imagePath: state.imagePath,
+            imagePath: persistedImagePath,
             tagIds: state.selectedTagIds.toList(),
           ),
         );
@@ -196,7 +204,7 @@ class ProjectFormNotifier extends Notifier<ProjectFormState> {
             memo: state.memo,
             gaugeStitches: state.gaugeStitches,
             gaugeRows: state.gaugeRows,
-            imagePath: state.imagePath,
+            imagePath: persistedImagePath,
             tagIds: state.selectedTagIds.toList(),
           ),
         );
@@ -205,6 +213,36 @@ class ProjectFormNotifier extends Notifier<ProjectFormState> {
       state = state.copyWith(isSaving: false, error: '프로젝트 저장 실패: $e');
       _emit(ShowProjectFormErrorMessage('프로젝트 저장 실패: $e'));
     }
+  }
+
+  /// 이미지를 앱 영구 저장소로 복사하고 상대 경로를 반환
+  /// - 이미지가 없으면 null 반환
+  /// - 이미 상대 경로(영구 저장소)이면 그대로 반환
+  /// - 새 이미지면 복사하고, 기존 이미지(oldPath)가 있으면 삭제
+  Future<String?> _persistImage({
+    required String? newPath,
+    required String? oldPath,
+  }) async {
+    // 이미지 제거된 경우
+    if (newPath == null) {
+      await ProjectImageUtils.deleteImage(oldPath);
+      return null;
+    }
+
+    // 이미 상대 경로(영구 저장소)이면 그대로 사용 (수정 모드에서 변경 안 한 경우)
+    if (!newPath.startsWith('/')) {
+      return newPath;
+    }
+
+    // 영구 저장소로 복사, 상대 경로 반환
+    final relativePath = await ProjectImageUtils.persistImage(newPath);
+
+    // 기존 이미지 파일 삭제 (수정 모드에서 이미지 교체된 경우)
+    if (oldPath != null && oldPath != newPath) {
+      await ProjectImageUtils.deleteImage(oldPath);
+    }
+
+    return relativePath;
   }
 
   // 헬퍼: DB에서 불러온 JSON 문자열 태그 ID 파싱

--- a/lib/modules/projects/application/projects_notifier.dart
+++ b/lib/modules/projects/application/projects_notifier.dart
@@ -48,6 +48,8 @@ class ProjectsNotifier extends Notifier<ProjectsState> {
         await _loadData();
 
       case ProjectsUpdated(:final projects):
+        // 태그 목록도 갱신 (프로젝트 생성 시 새 태그가 추가될 수 있음)
+        final tags = await appDb.getAllTags();
         // 필터링과 상태 업데이트를 한 번에 처리
         final ids = state.selectedTagIds;
         final filtered = ids.isEmpty
@@ -58,6 +60,7 @@ class ProjectsNotifier extends Notifier<ProjectsState> {
         state = state.copyWith(
           allProjects: projects,
           filteredProjects: filtered,
+          allTags: tags,
           isLoading: false,
           error: null,
         );

--- a/lib/new_project_screen.dart
+++ b/lib/new_project_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
@@ -8,6 +6,7 @@ import 'package:yarnie/db/app_db.dart';
 import 'package:yarnie/modules/projects/projects_api.dart';
 import 'package:yarnie/project_detail_screen.dart';
 import 'package:yarnie/widgets/colored_tag_chip.dart';
+import 'package:yarnie/widgets/project_image.dart';
 import 'package:yarnie/widgets/tag_selection_sheet.dart';
 import 'package:yarnie/l10n/app_localizations.dart';
 import 'package:yarnie/core/providers/length_unit_provider.dart';
@@ -432,7 +431,7 @@ class _ProjectImageSection extends StatelessWidget {
                   if (imagePath != null) ...[
                     // Preview Image
                     Positioned.fill(
-                      child: Image.file(File(imagePath!), fit: BoxFit.cover),
+                      child: ProjectImage(imagePath: imagePath, fit: BoxFit.cover),
                     ),
                     // Button Area Gradient
                     Positioned(

--- a/lib/project_info_screen.dart
+++ b/lib/project_info_screen.dart
@@ -1,9 +1,9 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yarnie/db/app_db.dart';
 import 'package:yarnie/new_project_screen.dart';
 import 'package:yarnie/widgets/colored_tag_chip.dart';
+import 'package:yarnie/widgets/project_image.dart';
 import 'package:yarnie/l10n/app_localizations.dart';
 import 'package:yarnie/core/providers/length_unit_provider.dart';
 
@@ -156,26 +156,24 @@ class ProjectInfoSheet extends ConsumerWidget {
                               child:
                                   (project.imagePath != null &&
                                       project.imagePath!.isNotEmpty)
-                                  ? Image.file(
-                                      File(project.imagePath!),
+                                  ? ProjectImage(
+                                      imagePath: project.imagePath,
                                       fit: BoxFit.cover,
-                                      errorBuilder: (context, error, stackTrace) {
-                                        return Container(
-                                          color: Theme.of(
-                                            context,
-                                          ).colorScheme.surfaceContainerHighest,
-                                          child: Center(
-                                            child: Icon(
-                                              Icons
-                                                  .image_not_supported_outlined,
-                                              size: 40,
-                                              color: Theme.of(
-                                                context,
-                                              ).colorScheme.onSurfaceVariant,
-                                            ),
+                                      placeholder: Container(
+                                        color: Theme.of(
+                                          context,
+                                        ).colorScheme.surfaceContainerHighest,
+                                        child: Center(
+                                          child: Icon(
+                                            Icons
+                                                .image_not_supported_outlined,
+                                            size: 40,
+                                            color: Theme.of(
+                                              context,
+                                            ).colorScheme.onSurfaceVariant,
                                           ),
-                                        );
-                                      },
+                                        ),
+                                      ),
                                     )
                                   : Container(
                                       color: Theme.of(

--- a/lib/widgets/project_image.dart
+++ b/lib/widgets/project_image.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import '../../core/utils/project_image_utils.dart';
+
+/// 프로젝트 이미지를 표시하는 위젯
+///
+/// DB에 저장된 상대 경로를 절대 경로로 변환하여 이미지를 로드합니다.
+/// 이미지가 없거나 로드 실패 시 [placeholder]를 표시합니다.
+class ProjectImage extends StatelessWidget {
+  final String? imagePath;
+  final BoxFit fit;
+  final Widget? placeholder;
+
+  const ProjectImage({
+    super.key,
+    required this.imagePath,
+    this.fit = BoxFit.cover,
+    this.placeholder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (imagePath == null) {
+      return placeholder ?? Container(color: const Color(0xFFD9D9D9));
+    }
+
+    return FutureBuilder<String?>(
+      future: ProjectImageUtils.toAbsolutePath(imagePath),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData || snapshot.data == null) {
+          return placeholder ?? Container(color: const Color(0xFFD9D9D9));
+        }
+        final absPath = snapshot.data!;
+        return Image.file(
+          File(absPath),
+          fit: fit,
+          errorBuilder: (_, __, ___) =>
+              placeholder ?? Container(color: const Color(0xFFD9D9D9)),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/project_list_tile.dart
+++ b/lib/widgets/project_list_tile.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:yarnie/l10n/app_localizations.dart';
 import '../db/app_db.dart';
-import 'colored_tag_chip.dart'; // Tag를 표시하기 위한 기존 위젯이라고 가정
+import 'colored_tag_chip.dart';
+import 'project_image.dart';
 
 class ProjectListTile extends StatelessWidget {
   final Project project;
@@ -49,11 +50,9 @@ class ProjectListTile extends StatelessWidget {
                 child: project.imagePath != null
                     ? ClipRRect(
                         borderRadius: BorderRadius.circular(4),
-                        child: Image.network(
-                          project.imagePath!,
+                        child: ProjectImage(
+                          imagePath: project.imagePath,
                           fit: BoxFit.cover,
-                          errorBuilder: (_, __, ___) =>
-                              Container(color: const Color(0xFFD9D9D9)),
                         ),
                       )
                     : Container(color: const Color(0xFFD9D9D9)),


### PR DESCRIPTION
- 기기 내 앱 저장 위치(절대 경로)에 의존하지 않고, 내부 폴더를 기준 삼는 '상대 경로'로 이미지를 저장하고 불러오도록 구조를 전면 개편함
- 이를 통해 앱 재설치나 업데이트 시 OS 정책(예: iOS Sandbox 경로 변경)에 의해 기존 이미지가 깨지는 현상을 근본적으로 해결함
- 안정적인 이미지 처리를 위해 전용 공통 위젯을 만들고, 관련된 모든 UI 화면과 상태 관리 로직에 일괄 반영함