### PR TITLE
fix: 카운터 카드 overflow 개선 및 라벨 Tooltip 추가

### DIFF
--- a/lib/widgets/counter_card/base_counter_card.dart
+++ b/lib/widgets/counter_card/base_counter_card.dart
@@ -22,7 +22,6 @@ class BaseCounterCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 173,
       height: 160,
       decoration: BoxDecoration(
         color: backgroundColor ?? Theme.of(context).colorScheme.surface,
@@ -37,16 +36,47 @@ class BaseCounterCard extends StatelessWidget {
             child: SizedBox(
               height: 20,
               width: double.infinity,
-              child: Text(
-                label,
-                style: TextStyle(
-                  fontSize: 14,
-                  color: Theme.of(context).colorScheme.onSurface,
-                  letterSpacing: -0.15,
-                  fontWeight: FontWeight.w400, // Inter Regular
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final textStyle = TextStyle(
+                    fontSize: 14,
+                    color: Theme.of(context).colorScheme.onSurface,
+                    letterSpacing: -0.15,
+                    fontWeight: FontWeight.w400,
+                  );
+                  final textSpan = TextSpan(text: label, style: textStyle);
+                  final textPainter = TextPainter(
+                    text: textSpan,
+                    maxLines: 1,
+                    textDirection: TextDirection.ltr,
+                  )..layout(maxWidth: constraints.maxWidth);
+                  final isOverflowing = textPainter.didExceedMaxLines;
+
+                  final textWidget = Text(
+                    label,
+                    style: textStyle,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  );
+
+                  if (!isOverflowing) return textWidget;
+
+                  return Tooltip(
+                    message: label,
+                    triggerMode: TooltipTriggerMode.tap,
+                    preferBelow: false,
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.inverseSurface,
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    textStyle: TextStyle(
+                      fontSize: 13,
+                      color: Theme.of(context).colorScheme.onInverseSurface,
+                      letterSpacing: -0.15,
+                    ),
+                    child: textWidget,
+                  );
+                },
               ),
             ),
           ),

--- a/lib/widgets/counter_card/stitch_counter_card.dart
+++ b/lib/widgets/counter_card/stitch_counter_card.dart
@@ -31,81 +31,75 @@ class StitchCounterCard extends StatelessWidget {
     return BaseCounterCard(
       label: label,
       progress: null, // 스티치 카운터는 프로그레스 바 없음
-      content: SizedBox(
-        width: 156,
-        height: 55,
-        child: Stack(
+      content: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             // Decrease Button
-            Positioned(
-              left: 0,
-              top: 7.5,
-              child: GestureDetector(
-                onTap: onDecrement,
-                child: Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.surface,
-                    shape: BoxShape.circle,
-                    border: Border.all(color: Theme.of(context).colorScheme.outline, width: 0.52),
-                  ),
-                  alignment: Alignment.center,
-                  child: Icon(Icons.remove, size: 16, color: Theme.of(context).colorScheme.onSurface),
+            GestureDetector(
+              onTap: onDecrement,
+              child: Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surface,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Theme.of(context).colorScheme.outline, width: 0.52),
+                ),
+                alignment: Alignment.center,
+                child: Icon(Icons.remove, size: 16, color: Theme.of(context).colorScheme.onSurface),
+              ),
+            ),
+            const SizedBox(width: 4),
+
+            // Value Display
+            Expanded(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.baseline,
+                  textBaseline: TextBaseline.alphabetic,
+                  children: [
+                    Text(
+                      '$currentValue',
+                      style: TextStyle(
+                        fontSize: 36,
+                        fontWeight: FontWeight.w400,
+                        color: Theme.of(context).colorScheme.onSurface,
+                        letterSpacing: 0.37,
+                        height: 1.0,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      AppLocalizations.of(context)!.stitch,
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w400,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        letterSpacing: -0.15,
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
-            
-            // Value Display
-            Positioned(
-              left: 48,
-              top: 9,
-              right: 48, // Center between buttons
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.baseline,
-                textBaseline: TextBaseline.alphabetic,
-                children: [
-                  Text(
-                    '$currentValue',
-                    style: TextStyle(
-                      fontSize: 36,
-                      fontWeight: FontWeight.w400,
-                      color: Theme.of(context).colorScheme.onSurface,
-                      letterSpacing: 0.37,
-                      height: 1.0,
-                    ),
-                  ),
-                  const SizedBox(width: 4),
-                  Text(
-                    AppLocalizations.of(context)!.stitch,
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w400,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      letterSpacing: -0.15,
-                    ),
-                  ),
-                ],
-              ),
-            ),
+            const SizedBox(width: 4),
 
             // Increase Button
-            Positioned(
-              right: 0,
-              top: 7.5,
-              child: GestureDetector(
-                onTap: onIncrement,
-                child: Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.primary,
-                    shape: BoxShape.circle,
-                  ),
-                  alignment: Alignment.center,
-                  child: Icon(Icons.add, size: 16, color: Theme.of(context).colorScheme.surface),
+            GestureDetector(
+              onTap: onIncrement,
+              child: Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary,
+                  shape: BoxShape.circle,
                 ),
+                alignment: Alignment.center,
+                child: Icon(Icons.add, size: 16, color: Theme.of(context).colorScheme.surface),
               ),
             ),
           ],


### PR DESCRIPTION
- 라벨이 잘릴 때 탭하면 Tooltip으로 전체 이름 표시
- 잘리지 않은 라벨은 Tooltip 비활성화 (TextPainter 체크)
- BaseCounterCard 고정 너비(173px) 제거로 다양한 화면 대응
- StitchCounterCard Stack→Row+FittedBox 전환으로 값 overflow 해결