### PR TITLE
fix: interval counter 컬러칩 표시 및 텍스트 개선

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -476,5 +476,7 @@
   "premiumRestoreNoHistory": "No purchase history found to restore.",
   "premiumNetworkError": "A network error occurred. Please check your connection.",
   "upsellSnackbarMessage": "Purchase Yarnie Premium to create unlimited projects!",
-  "upsellSnackbarAction": "View Premium"
+  "upsellSnackbarAction": "View Premium",
+  "everyNRows": "Every {n} rows",
+  "row": "rows"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -477,5 +477,7 @@
   "premiumRestoreNoHistory": "복원할 구매 내역이 없습니다.",
   "premiumNetworkError": "네트워크 오류가 발생했습니다. 연결 상태를 확인해주세요.",
   "upsellSnackbarMessage": "Yarnie 평생권을 구입하시면 무제한으로 만드실 수 있어요!",
-  "upsellSnackbarAction": "프리미엄 보기"
+  "upsellSnackbarAction": "프리미엄 보기",
+  "everyNRows": "{n}행마다",
+  "row": "행"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2959,6 +2959,18 @@ abstract class AppLocalizations {
   /// In ko, this message translates to:
   /// **'프리미엄 보기'**
   String get upsellSnackbarAction;
+
+  /// No description provided for @everyNRows.
+  ///
+  /// In ko, this message translates to:
+  /// **'{n}행마다'**
+  String everyNRows(Object n);
+
+  /// No description provided for @row.
+  ///
+  /// In ko, this message translates to:
+  /// **'행'**
+  String get row;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1576,4 +1576,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get upsellSnackbarAction => 'View Premium';
+
+  @override
+  String everyNRows(Object n) {
+    return 'Every $n rows';
+  }
+
+  @override
+  String get row => 'rows';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1521,4 +1521,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get upsellSnackbarAction => '프리미엄 보기';
+
+  @override
+  String everyNRows(Object n) {
+    return '$n행마다';
+  }
+
+  @override
+  String get row => '행';
 }

--- a/lib/project_detail_screen.dart
+++ b/lib/project_detail_screen.dart
@@ -1421,11 +1421,31 @@ class SectionCounterCardWrapper extends ConsumerWidget {
         final startRowInt = spec['startRow'] as int? ?? 1;
 
         int completedCount = 0;
-        for (final r in runs) {
+        int activeRunIndex = -1;
+        for (int i = 0; i < runs.length; i++) {
+          final r = runs[i];
           if (effectiveValue >= r.startRow + r.rowsTotal) {
             completedCount++;
           } else if (effectiveValue >= r.startRow) {
+            activeRunIndex = i;
             break;
+          }
+        }
+
+        // 현재 활성 run의 색상 정보 추출
+        // activeRunIndex가 있으면 해당 run, 없으면 마지막 완료 run
+        Color? currentColor;
+        String? currentColorLabel;
+        final displayRunIndex = activeRunIndex >= 0
+            ? activeRunIndex
+            : (completedCount > 0 ? completedCount - 1 : 0);
+        if (displayRunIndex < runs.length) {
+          final displayRun = runs[displayRunIndex];
+          if (displayRun.label != null && displayRun.label!.startsWith('#')) {
+            try {
+              final hexStr = displayRun.label!.substring(1);
+              currentColor = Color(int.parse(hexStr, radix: 16) + 0xFF000000);
+            } catch (_) {}
           }
         }
 
@@ -1444,6 +1464,8 @@ class SectionCounterCardWrapper extends ConsumerWidget {
             isLinked: counter.linkState == LinkState.linked,
             backgroundColor: backgroundColor,
             isCompleted: isCompleted,
+            currentColor: currentColor,
+            currentColorLabel: currentColorLabel,
             onLinkTap: () {
               if (counter.linkState == LinkState.linked) {
                 appDb.unlinkSectionCounter(

--- a/lib/widgets/counter_card/interval_counter_card.dart
+++ b/lib/widgets/counter_card/interval_counter_card.dart
@@ -14,6 +14,8 @@ class IntervalCounterCard extends StatelessWidget {
   final VoidCallback? onDelete;
   final Color? backgroundColor;
   final bool isCompleted;
+  final Color? currentColor; // 현재 활성 인터벌의 색상
+  final String? currentColorLabel; // 현재 활성 인터벌의 라벨
 
   const IntervalCounterCard({
     super.key,
@@ -28,11 +30,22 @@ class IntervalCounterCard extends StatelessWidget {
     this.onDelete,
     this.backgroundColor,
     this.isCompleted = false,
+    this.currentColor,
+    this.currentColorLabel,
   });
 
   @override
   Widget build(BuildContext context) {
     final progressRatio = totalCount > 0 ? currentCount / totalCount : 0.0;
+    final l10n = AppLocalizations.of(context)!;
+
+    // 하단 info text: "시작행~종료행" or "시작행~"
+    final endRow = totalCount > 0
+        ? startRow + (intervalRows * totalCount) - 1
+        : null;
+    final infoText = endRow != null
+        ? '$startRow~$endRow${l10n.row}'
+        : l10n.fromRow(startRow);
 
     return BaseCounterCard(
       label: label,
@@ -42,28 +55,67 @@ class IntervalCounterCard extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Text(
-            '$intervalRows${AppLocalizations.of(context)!.stitch}',
+            l10n.everyNRows(intervalRows),
             style: TextStyle(
               fontSize: 14,
               color: Theme.of(context).colorScheme.onSurfaceVariant,
               letterSpacing: -0.15,
             ),
           ),
-          const SizedBox(height: 2),
-          Text(
-            '$currentCount/$totalCount${isCompleted ? ' ✓' : ''}',
-            style: TextStyle(
-              fontSize: 24,
-              fontWeight: FontWeight.w400,
-              color: Theme.of(context).colorScheme.onSurface,
-              letterSpacing: 0.07,
-              height: 1.33,
+          const SizedBox(height: 4),
+          if (currentColor != null) ...[
+            // 컬러칩 + 라벨 표시
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 28,
+                  height: 28,
+                  decoration: BoxDecoration(
+                    color: currentColor,
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                      color: Theme.of(context).colorScheme.outline,
+                      width: 0.5,
+                    ),
+                  ),
+                ),
+                if (currentColorLabel != null && currentColorLabel!.isNotEmpty) ...[
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      currentColorLabel!,
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                        color: Theme.of(context).colorScheme.onSurface,
+                        letterSpacing: -0.15,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ],
             ),
-          ),
+          ] else ...[
+            // 컬러칩 없는 경우: 기존 숫자 표시
+            Text(
+              '$currentCount/$totalCount${isCompleted ? ' ✓' : ''}',
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.w400,
+                color: Theme.of(context).colorScheme.onSurface,
+                letterSpacing: 0.07,
+                height: 1.33,
+              ),
+            ),
+          ],
         ],
       ),
       bottomToolbar: CounterCardToolbar(
-        infoText: AppLocalizations.of(context)!.fromRow(startRow),
+        infoText: infoText,
         showLinkButton: true,
         isLinked: isLinked,
         onLinkTap: onLinkTap,


### PR DESCRIPTION
- IntervalCounterCard에 currentColor 파라미터 추가하여 palette 색상을 원형 컬러칩으로 표시
- SectionRun label의 HEX 값을 파싱하여 카드에 전달
- 카드 상단 텍스트를 stitch(코) → everyNRows(N행마다)로 수정
- 하단 info text를 시작행~종료행 형식으로 개선
- everyNRows, row 로컬라이제이션 키 추가 (ko/en)