### PR TITLE
refactor: 카운터 진행도 UX 개선 및 Shaping 카운터 직관성 강화

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -283,7 +283,7 @@
   "stitchIncrease": "Increase",
   "stitchDecrease": "Decrease",
   "nextRow": "Next:{row}",
-  "patternRows": "{current}/{total} rows ({total} row pattern)",
+  "patternRows": "Row {current} of {total}",
   "fromRow": "From row {row}",
   "stitch": "sts",
   "increaseBy": "+{n} each",
@@ -478,5 +478,31 @@
   "upsellSnackbarMessage": "Purchase Yarnie Premium to create unlimited projects!",
   "upsellSnackbarAction": "View Premium",
   "everyNRows": "Every {n} rows",
-  "row": "rows"
+  "row": "rows",
+  "repeatCountSuffix": "/ {count} times{checkmark}",
+  "shapingDecrease": "Dec {n} sts",
+  "@shapingDecrease": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "shapingIncrease": "Inc {n} sts",
+  "@shapingIncrease": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "shapingActionNow": "NOW!",
+  "shapingActionNotYet": "Work even (Next: {row})",
+  "@shapingActionNotYet": {
+    "placeholders": {
+      "row": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -105,7 +105,7 @@
   "shapingCounterUsage3": "• 목둘레나 어깨선 줄임",
   "shapingCounterExample": "\"양쪽에서 6회 늘림: 68코 → 80코\"",
   "lengthCounter": "길이 카운터 (Length)",
-  "lengthCounterDesc": "특정 길이에 도달할 때까지 작업을 추적해요.",
+  "lengthCounterDesc": "목표 길이까지 필요한 단수를 추적합니다",
   "lengthCounterUsage1": "• \"30cm까지 뜨기\" 같은 길이 기반 작업",
   "lengthCounterUsage2": "• 스카프나 담요의 원하는 길이 도달",
   "lengthCounterUsage3": "• 소매 길이나 몸통 길이 추적",
@@ -282,7 +282,7 @@
   "stitchIncrease": "코 늘림",
   "stitchDecrease": "코 줄임",
   "nextRow": "다음:{row}행",
-  "patternRows": "{current}/{total}행 ({total}행 패턴)",
+  "patternRows": "{current}/{total}행",
   "fromRow": "{row}행부터",
   "stitch": "코",
   "increaseBy": "+{n}씩",
@@ -321,7 +321,6 @@
   "targetInfoLengthInch": "목표 {length}inch",
   "editLengthCounterTitle": "길이 측정 카운터 수정",
   "addLengthCounterTitle": "길이 측정 카운터 추가",
-  "lengthCounterDesc": "목표 길이까지 필요한 단수를 추적합니다",
   "startStitch": "시작 단",
   "targetLengthCm": "목표 길이 (cm)",
   "targetLengthInch": "목표 길이 (inch)",
@@ -479,5 +478,41 @@
   "upsellSnackbarMessage": "Yarnie 평생권을 구입하시면 무제한으로 만드실 수 있어요!",
   "upsellSnackbarAction": "프리미엄 보기",
   "everyNRows": "{n}행마다",
-  "row": "행"
+  "row": "행",
+  "repeatCountSuffix": "/ {count}회{checkmark}",
+  "@repeatCountSuffix": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "checkmark": {
+        "type": "String"
+      }
+    }
+  },
+  "shapingDecrease": "{n}코 줄임",
+  "@shapingDecrease": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "shapingIncrease": "{n}코 늘림",
+  "@shapingIncrease": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "shapingActionNow": "지금 바로 진행!",
+  "shapingActionNotYet": "평단 (다음: {row}행)",
+  "@shapingActionNotYet": {
+    "placeholders": {
+      "row": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1793,7 +1793,7 @@ abstract class AppLocalizations {
   /// No description provided for @patternRows.
   ///
   /// In ko, this message translates to:
-  /// **'{current}/{total}행 ({total}행 패턴)'**
+  /// **'{current}/{total}행'**
   String patternRows(Object current, Object total);
 
   /// No description provided for @fromRow.
@@ -2971,6 +2971,36 @@ abstract class AppLocalizations {
   /// In ko, this message translates to:
   /// **'행'**
   String get row;
+
+  /// No description provided for @repeatCountSuffix.
+  ///
+  /// In ko, this message translates to:
+  /// **'/ {count}회{checkmark}'**
+  String repeatCountSuffix(int count, String checkmark);
+
+  /// No description provided for @shapingDecrease.
+  ///
+  /// In ko, this message translates to:
+  /// **'{n}코 줄임'**
+  String shapingDecrease(int n);
+
+  /// No description provided for @shapingIncrease.
+  ///
+  /// In ko, this message translates to:
+  /// **'{n}코 늘림'**
+  String shapingIncrease(int n);
+
+  /// No description provided for @shapingActionNow.
+  ///
+  /// In ko, this message translates to:
+  /// **'지금 바로 진행!'**
+  String get shapingActionNow;
+
+  /// No description provided for @shapingActionNotYet.
+  ///
+  /// In ko, this message translates to:
+  /// **'평단 (다음: {row}행)'**
+  String shapingActionNotYet(int row);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -949,7 +949,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String patternRows(Object current, Object total) {
-    return '$current/$total rows ($total row pattern)';
+    return 'Row $current of $total';
   }
 
   @override
@@ -1584,4 +1584,27 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get row => 'rows';
+
+  @override
+  String repeatCountSuffix(int count, String checkmark) {
+    return '/ $count times$checkmark';
+  }
+
+  @override
+  String shapingDecrease(int n) {
+    return 'Dec $n sts';
+  }
+
+  @override
+  String shapingIncrease(int n) {
+    return 'Inc $n sts';
+  }
+
+  @override
+  String get shapingActionNow => 'NOW!';
+
+  @override
+  String shapingActionNotYet(int row) {
+    return 'Work even (Next: $row)';
+  }
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -904,7 +904,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String patternRows(Object current, Object total) {
-    return '$current/$total행 ($total행 패턴)';
+    return '$current/$total행';
   }
 
   @override
@@ -1529,4 +1529,27 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get row => '행';
+
+  @override
+  String repeatCountSuffix(int count, String checkmark) {
+    return '/ $count회$checkmark';
+  }
+
+  @override
+  String shapingDecrease(int n) {
+    return '$n코 줄임';
+  }
+
+  @override
+  String shapingIncrease(int n) {
+    return '$n코 늘림';
+  }
+
+  @override
+  String get shapingActionNow => '지금 바로 진행!';
+
+  @override
+  String shapingActionNotYet(int row) {
+    return '평단 (다음: $row행)';
+  }
 }

--- a/lib/project_detail_screen.dart
+++ b/lib/project_detail_screen.dart
@@ -106,7 +106,7 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
 
       if (type == 'range') {
         final run = runs.first;
-        final end = run.startRow + run.rowsTotal - 1;
+        final end = run.startRow + run.rowsTotal;
         wasCompleted = oldVal >= end;
         isCompleted = newVal >= end;
       } else if (type == 'repeat') {
@@ -155,7 +155,7 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
         final rowHeight = spec['rowHeight'] as double? ?? 0.1;
 
         bool check(int val) {
-          final rowsDone = (val - runL.startRow + 1).clamp(0, runL.rowsTotal);
+          final rowsDone = (val - runL.startRow).clamp(0, runL.rowsTotal);
           final rowsLeft = runL.rowsTotal - rowsDone;
           final remainingLen = (rowsLeft * rowHeight).clamp(0.0, targetLength);
           final progressL = runL.rowsTotal > 0
@@ -1271,7 +1271,7 @@ class SectionCounterCardWrapper extends ConsumerWidget {
         if (runs.isEmpty) return Text('No Data');
         final run = runs.first;
         final isCompleted =
-            effectiveValue >= (run.startRow + run.rowsTotal - 1);
+            effectiveValue >= (run.startRow + run.rowsTotal);
         final backgroundColor = isCompleted
             ? completedColor
             : (counter.linkState == LinkState.linked ? null : unlinkedColor);
@@ -1513,16 +1513,20 @@ class SectionCounterCardWrapper extends ConsumerWidget {
         final startRowShaping = spec['startRow'] as int? ?? 1;
 
         int shapingCompleted = 0;
-        int nextActionRow = startRowShaping + intervalRowsShaping;
+        int nextActionRow = startRowShaping;
 
         for (int i = 0; i < runs.length; i++) {
           final r = runs[i];
-          final actionRow = r.startRow + r.rowsTotal;
+          final runEndRow = r.startRow + r.rowsTotal;
 
-          if (effectiveValue >= actionRow) {
+          if (effectiveValue >= runEndRow) {
             shapingCompleted++;
           } else {
-            nextActionRow = actionRow;
+            if (effectiveValue <= r.startRow) {
+              nextActionRow = r.startRow;
+            } else {
+              nextActionRow = runEndRow;
+            }
             break;
           }
         }
@@ -1548,6 +1552,7 @@ class SectionCounterCardWrapper extends ConsumerWidget {
             isLinked: counter.linkState == LinkState.linked,
             backgroundColor: backgroundColor,
             isCompleted: isCompleted,
+            isActionRow: effectiveValue == nextActionRow && !isCompleted,
             onLinkTap: () {
               if (counter.linkState == LinkState.linked) {
                 appDb.unlinkSectionCounter(
@@ -1597,7 +1602,7 @@ class SectionCounterCardWrapper extends ConsumerWidget {
         final rowHeight = (spec['rowHeight'] as num? ?? 0.1).toDouble();
         final unitInSpec = spec['units']?.toString() ?? 'cm';
 
-        final rowsDone = (effectiveValue - runL.startRow + 1).clamp(
+        final rowsDone = (effectiveValue - runL.startRow).clamp(
           0,
           runL.rowsTotal,
         );

--- a/lib/widgets/counter_card/range_counter_card.dart
+++ b/lib/widgets/counter_card/range_counter_card.dart
@@ -34,10 +34,13 @@ class RangeCounterCard extends StatelessWidget {
   Widget build(BuildContext context) {
     // Calculate progress (clamp 0..totalRows)
     // Range: startRow ~ endRow
-    // If current < startRow: 0
-    // If current > endRow: totalRows
-    final progressValue = (currentMainValue - startRow + 1).clamp(0, totalRows);
-    final progressRatio = totalRows > 0 ? progressValue / totalRows : 0.0;
+    // Progress = completed rows (not including current row)
+    // e.g. startRow=1, current=1 → 0 completed (0%), current=2 → 1 completed (10%)
+    final completedRows = (currentMainValue - startRow).clamp(0, totalRows);
+    final progressRatio = totalRows > 0 ? completedRows / totalRows : 0.0;
+    
+    // Display = current active row in this range (1-based index)
+    final displayValue = (currentMainValue - startRow + 1).clamp(0, totalRows);
 
     return BaseCounterCard(
       label: label,
@@ -49,7 +52,7 @@ class RangeCounterCard extends StatelessWidget {
         textBaseline: TextBaseline.alphabetic,
         children: [
           Text(
-            '$progressValue',
+            '$displayValue',
             style: TextStyle(
               fontSize: 36,
               fontWeight: FontWeight.w400,
@@ -60,7 +63,7 @@ class RangeCounterCard extends StatelessWidget {
           ),
           const SizedBox(width: 4),
           Text(
-            '/ $totalRows${AppLocalizations.of(context)!.stitch}${isCompleted ? ' ✓' : ''}',
+            '/ $totalRows${AppLocalizations.of(context)!.row}${isCompleted ? ' ✓' : ''}',
             style: TextStyle(
               fontSize: 14,
               fontWeight: FontWeight.w400,
@@ -71,7 +74,7 @@ class RangeCounterCard extends StatelessWidget {
         ],
       ),
       bottomToolbar: CounterCardToolbar(
-        infoText: '$startRow~$endRow${AppLocalizations.of(context)!.stitch}',
+        infoText: '$startRow~$endRow${AppLocalizations.of(context)!.row}',
         showLinkButton: true,
         isLinked: isLinked,
         onLinkTap: onLinkTap,

--- a/lib/widgets/counter_card/repeat_counter_card.dart
+++ b/lib/widgets/counter_card/repeat_counter_card.dart
@@ -34,11 +34,11 @@ class RepeatCounterCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Total progress across all repeats? Or just current repeat?
-    // Design shows progress bar. Usually represents total completion.
-    // Let's assume linear progress: (currentRepeat * rowsPerRepeat + currentRow) / (maxRepeat * rowsPerRepeat)
+    // Total progress across all repeats.
+    // Progress = completed rows (not including current row in pattern)
+    // e.g. repeat 0, row 1 → 0 completed (0%)
     final totalRows = maxRepeatCount * rowsPerRepeat;
-    final currentTotal = (currentRepeatCount * rowsPerRepeat) + currentRowInPattern;
+    final currentTotal = (currentRepeatCount * rowsPerRepeat) + (currentRowInPattern - 1);
     final progressRatio = totalRows > 0 ? currentTotal / totalRows : 0.0;
 
     return BaseCounterCard(
@@ -54,8 +54,7 @@ class RepeatCounterCard extends StatelessWidget {
             textBaseline: TextBaseline.alphabetic,
             children: [
               Text(
-                '${currentRepeatCount + 1}', // Display 1-based for user? Or 0? Design shows '0 / 5회' -> maybe completed count?
-                // If '0 / 5회' means 0 completed, then we use currentRepeatCount.
+                '${(currentRepeatCount + 1).clamp(1, maxRepeatCount)}',
                 style: TextStyle(
                   fontSize: 36,
                   fontWeight: FontWeight.w400,
@@ -66,7 +65,7 @@ class RepeatCounterCard extends StatelessWidget {
               ),
               const SizedBox(width: 4),
               Text(
-                '/ ${maxRepeatCount}회${isCompleted ? ' ✓' : ''}',
+                AppLocalizations.of(context)!.repeatCountSuffix(maxRepeatCount, isCompleted ? ' ✓' : ''),
                 style: TextStyle(
                   fontSize: 14,
                   fontWeight: FontWeight.w400,

--- a/lib/widgets/counter_card/shaping_counter_card.dart
+++ b/lib/widgets/counter_card/shaping_counter_card.dart
@@ -16,6 +16,7 @@ class ShapingCounterCard extends StatelessWidget {
   final VoidCallback? onDelete;
   final Color? backgroundColor;
   final bool isCompleted;
+  final bool isActionRow; // 현재 행이 코 줄임/늘림을 실행해야 하는 행인지 여부
 
   const ShapingCounterCard({
     super.key,
@@ -32,6 +33,7 @@ class ShapingCounterCard extends StatelessWidget {
     this.onDelete,
     this.backgroundColor,
     this.isCompleted = false,
+    this.isActionRow = false,
   });
 
   @override
@@ -41,8 +43,8 @@ class ShapingCounterCard extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     // Determine icon and text based on amount
     final isIncrease = amount > 0;
-    final typeText = isIncrease ? l10n.stitchIncrease : l10n.stitchDecrease;
-    final amountText = isIncrease ? '+$amount${l10n.stitch}' : '$amount${l10n.stitch}';
+    final amountAbs = amount.abs();
+    final actionText = isIncrease ? l10n.shapingIncrease(amountAbs) : l10n.shapingDecrease(amountAbs);
     final color = isIncrease ? const Color(0xFF6FB96F) : const Color(0xFFF08C1F); // Green for +, Orange for -
 
     return BaseCounterCard(
@@ -64,7 +66,7 @@ class ShapingCounterCard extends StatelessWidget {
               ),
               const SizedBox(width: 4),
               Text(
-                '$typeText $amountText',
+                actionText,
                 style: TextStyle(
                   fontSize: 12,
                   color: Theme.of(context).colorScheme.onSurfaceVariant,
@@ -75,16 +77,45 @@ class ShapingCounterCard extends StatelessWidget {
           ),
           
           // Next Action Row
-          Text(
-            isCompleted ? '${l10n.complete} ✓' : l10n.nextRow(nextActionRow),
-            style: TextStyle(
-              fontSize: 20,
-              fontWeight: FontWeight.w400,
-              color: Theme.of(context).colorScheme.onSurface,
-              letterSpacing: -0.44,
-              height: 1.4,
+          if (isCompleted)
+            Text(
+              '${l10n.complete} ✓',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w400,
+                color: Theme.of(context).colorScheme.onSurface,
+                letterSpacing: -0.44,
+                height: 1.4,
+              ),
+            )
+          else if (isActionRow)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Text(
+                l10n.shapingActionNow,
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                  color: color,
+                  letterSpacing: -0.3,
+                ),
+              ),
+            )
+          else
+            Text(
+              l10n.shapingActionNotYet(nextActionRow), 
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w400,
+                color: Theme.of(context).colorScheme.onSurface,
+                letterSpacing: -0.44,
+                height: 1.4,
+              ),
             ),
-          ),
           
           // Sub Info
           Text(


### PR DESCRIPTION
- 모든 카운터(Range, Repeat, Length)의 프로그레스바가 '현재 단'을 포함하지 않고 '완료된 단' 기준으로만 차오르도록 계산 방식 통일 (시작 시 0% 유지)
- 사용자에게 노출되는 진행 단수 텍스트는 1-based(현재 진행 중인 단)로 명확히 표시되도록 분리
- Shaping 카운터의 액션 단(Action Row) 도달 판정 로직을 수정하여, 목표 단을 통과하기 전까지는 완료 처리되지 않도록 개선
- Shaping 카운터가 코 증감 단에 도달했을 때 직관적인 알림('지금 바로 진행!' / 'NOW!')을 띄우고, 평단일 경우 목표 단을 안내('평단' / 'Work even')하도록 UI 개편
- 한국어/영어권의 실제 뜨개 용어(Inc/Dec, Work even 등)에 맞춰 다국어(.arb) 리소스 적용 및 텍스트 간소화
- Repeat 카운터 및 Range 카운터의 하드코딩된 단위('회', '코')를 다국어로 분리 및 수정