### PR TITLE
feat: shaping counter 직접 입력 모드 추가

### DIFF
--- a/lib/db/app_db.dart
+++ b/lib/db/app_db.dart
@@ -1359,23 +1359,49 @@ class AppDb extends _$AppDb {
       }
     } else if (type == 'shaping') {
       // Shaping 타입: 코 수 증감
-      final startRow = spec['startRow'] as int? ?? 0;
-      final intervalRows = spec['intervalRows'] as int? ?? 0;
-      final totalCount = spec['totalCount'] as int? ?? 0;
       final amount = spec['amount'] as int? ?? 0;
+      final mode = spec['mode'] as String?;
+      final label = amount > 0 ? '+$amount sts' : '$amount sts';
 
-      final label = amount > 0 ? '+$amount sts' : '$amount sts'; // +1 sts, -1 sts
+      if (mode == 'direct') {
+        // 직접 입력 모드: rows 배열에서 개별 run 생성
+        final List<dynamic> rowsList = spec['rows'] ?? [];
+        final rows = rowsList.map((e) => (e as int)).toList();
+        rows.sort();
 
-      for (var i = 0; i < totalCount; i++) {
-        await into(sectionRuns).insert(
-          SectionRunsCompanion.insert(
-            sectionCounterId: sectionCounterId,
-            ord: i,
-            startRow: startRow + (i * intervalRows),
-            rowsTotal: intervalRows,
-            label: Value(label),
-          ),
-        );
+        for (var i = 0; i < rows.length; i++) {
+          // rowsTotal = 다음 row까지의 거리, 마지막은 1
+          final rowsTotal = (i < rows.length - 1)
+              ? rows[i + 1] - rows[i]
+              : 1;
+
+          await into(sectionRuns).insert(
+            SectionRunsCompanion.insert(
+              sectionCounterId: sectionCounterId,
+              ord: i,
+              startRow: rows[i],
+              rowsTotal: rowsTotal,
+              label: Value(label),
+            ),
+          );
+        }
+      } else {
+        // 패턴 모드: 기존 로직
+        final startRow = spec['startRow'] as int? ?? 0;
+        final intervalRows = spec['intervalRows'] as int? ?? 0;
+        final totalCount = spec['totalCount'] as int? ?? 0;
+
+        for (var i = 0; i < totalCount; i++) {
+          await into(sectionRuns).insert(
+            SectionRunsCompanion.insert(
+              sectionCounterId: sectionCounterId,
+              ord: i,
+              startRow: startRow + (i * intervalRows),
+              rowsTotal: intervalRows,
+              label: Value(label),
+            ),
+          );
+        }
       }
     } else if (type == 'length') {
       // Length 타입: 단일 목표 구간

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -279,7 +279,7 @@
   "deleteConfirm": "Do you want to delete this project?",
   "deleteDesc": "The project will be moved to the trash and permanently deleted after 30 days.",
   "achieved": "Achieved ✓",
-  "remainingLength": "Remaining Length",
+  "remainingLength": "Remaining",
   "stitchIncrease": "Increase",
   "stitchDecrease": "Decrease",
   "nextRow": "Next:{row}",
@@ -421,7 +421,7 @@
   "expectedRows": "Expected Rows",
   "gaugeInputComingSoon": "Gauge input feature is coming soon",
   "goToGaugeInput": "Go to gauge input",
-  "lengthMeasurement": "Length Measurement",
+  "lengthMeasurement": "Length Counter",
   "manageParts": "Manage Parts",
   "managePartsDesc": "Long press a Part name to edit, or drag the left icon to reorder.",
   "newPartName": "New Part Name",
@@ -497,12 +497,20 @@
     }
   },
   "shapingActionNow": "NOW!",
-  "shapingActionNotYet": "Work even (Next: {row})",
-  "@shapingActionNotYet": {
+  "shapingWorkEven": "Work even",
+  "shapingNextActionRow": "Next: row {row}",
+  "@shapingNextActionRow": {
     "placeholders": {
       "row": {
         "type": "int"
       }
     }
-  }
+  },
+  "shapingModePattern": "Pattern",
+  "shapingModeDirect": "Direct",
+  "shapingRowsLabel": "Shaping Rows",
+  "shapingRowsHint": "e.g., 2, 5, 9, 11",
+  "shapingRowsHelper": "Enter row numbers for shaping, separated by commas",
+  "shapingDirectSubInfo": "{current}/{total} times",
+  "preview": "Preview"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -316,7 +316,7 @@
   "cm": "cm",
   "inch": "inch",
   "countBySetting": "Count By 설정",
-  "lengthMeasurement": "길이 측정",
+  "lengthMeasurement": "길이 카운터",
   "targetInfoLength": "목표 {length}cm",
   "targetInfoLengthInch": "목표 {length}inch",
   "editLengthCounterTitle": "길이 측정 카운터 수정",
@@ -507,12 +507,20 @@
     }
   },
   "shapingActionNow": "지금 바로 진행!",
-  "shapingActionNotYet": "평단 (다음: {row}행)",
-  "@shapingActionNotYet": {
+  "shapingWorkEven": "평단",
+  "shapingNextActionRow": "다음: {row}행",
+  "@shapingNextActionRow": {
     "placeholders": {
       "row": {
         "type": "int"
       }
     }
-  }
+  },
+  "shapingModePattern": "패턴",
+  "shapingModeDirect": "직접 입력",
+  "shapingRowsLabel": "증감 단수",
+  "shapingRowsHint": "예: 2, 5, 9, 11",
+  "shapingRowsHelper": "코를 증감할 단수를 쉼표로 구분하여 입력하세요",
+  "shapingDirectSubInfo": "{current}/{total}회",
+  "preview": "미리보기"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1997,7 +1997,7 @@ abstract class AppLocalizations {
   /// No description provided for @lengthMeasurement.
   ///
   /// In ko, this message translates to:
-  /// **'길이 측정'**
+  /// **'길이 카운터'**
   String get lengthMeasurement;
 
   /// No description provided for @targetInfoLength.
@@ -2996,11 +2996,59 @@ abstract class AppLocalizations {
   /// **'지금 바로 진행!'**
   String get shapingActionNow;
 
-  /// No description provided for @shapingActionNotYet.
+  /// No description provided for @shapingWorkEven.
   ///
   /// In ko, this message translates to:
-  /// **'평단 (다음: {row}행)'**
-  String shapingActionNotYet(int row);
+  /// **'평단'**
+  String get shapingWorkEven;
+
+  /// No description provided for @shapingNextActionRow.
+  ///
+  /// In ko, this message translates to:
+  /// **'다음: {row}행'**
+  String shapingNextActionRow(int row);
+
+  /// No description provided for @shapingModePattern.
+  ///
+  /// In ko, this message translates to:
+  /// **'패턴'**
+  String get shapingModePattern;
+
+  /// No description provided for @shapingModeDirect.
+  ///
+  /// In ko, this message translates to:
+  /// **'직접 입력'**
+  String get shapingModeDirect;
+
+  /// No description provided for @shapingRowsLabel.
+  ///
+  /// In ko, this message translates to:
+  /// **'증감 단수'**
+  String get shapingRowsLabel;
+
+  /// No description provided for @shapingRowsHint.
+  ///
+  /// In ko, this message translates to:
+  /// **'예: 2, 5, 9, 11'**
+  String get shapingRowsHint;
+
+  /// No description provided for @shapingRowsHelper.
+  ///
+  /// In ko, this message translates to:
+  /// **'코를 증감할 단수를 쉼표로 구분하여 입력하세요'**
+  String get shapingRowsHelper;
+
+  /// No description provided for @shapingDirectSubInfo.
+  ///
+  /// In ko, this message translates to:
+  /// **'{current}/{total}회'**
+  String shapingDirectSubInfo(Object current, Object total);
+
+  /// No description provided for @preview.
+  ///
+  /// In ko, this message translates to:
+  /// **'미리보기'**
+  String get preview;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -934,7 +934,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get achieved => 'Achieved ✓';
 
   @override
-  String get remainingLength => 'Remaining Length';
+  String get remainingLength => 'Remaining';
 
   @override
   String get stitchIncrease => 'Increase';
@@ -1058,7 +1058,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get countBySetting => 'Count By Setting';
 
   @override
-  String get lengthMeasurement => 'Length Measurement';
+  String get lengthMeasurement => 'Length Counter';
 
   @override
   String targetInfoLength(Object length) {
@@ -1604,7 +1604,34 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shapingActionNow => 'NOW!';
 
   @override
-  String shapingActionNotYet(int row) {
-    return 'Work even (Next: $row)';
+  String get shapingWorkEven => 'Work even';
+
+  @override
+  String shapingNextActionRow(int row) {
+    return 'Next: row $row';
   }
+
+  @override
+  String get shapingModePattern => 'Pattern';
+
+  @override
+  String get shapingModeDirect => 'Direct';
+
+  @override
+  String get shapingRowsLabel => 'Shaping Rows';
+
+  @override
+  String get shapingRowsHint => 'e.g., 2, 5, 9, 11';
+
+  @override
+  String get shapingRowsHelper =>
+      'Enter row numbers for shaping, separated by commas';
+
+  @override
+  String shapingDirectSubInfo(Object current, Object total) {
+    return '$current/$total times';
+  }
+
+  @override
+  String get preview => 'Preview';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1011,7 +1011,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get countBySetting => 'Count By 설정';
 
   @override
-  String get lengthMeasurement => '길이 측정';
+  String get lengthMeasurement => '길이 카운터';
 
   @override
   String targetInfoLength(Object length) {
@@ -1549,7 +1549,33 @@ class AppLocalizationsKo extends AppLocalizations {
   String get shapingActionNow => '지금 바로 진행!';
 
   @override
-  String shapingActionNotYet(int row) {
-    return '평단 (다음: $row행)';
+  String get shapingWorkEven => '평단';
+
+  @override
+  String shapingNextActionRow(int row) {
+    return '다음: $row행';
   }
+
+  @override
+  String get shapingModePattern => '패턴';
+
+  @override
+  String get shapingModeDirect => '직접 입력';
+
+  @override
+  String get shapingRowsLabel => '증감 단수';
+
+  @override
+  String get shapingRowsHint => '예: 2, 5, 9, 11';
+
+  @override
+  String get shapingRowsHelper => '코를 증감할 단수를 쉼표로 구분하여 입력하세요';
+
+  @override
+  String shapingDirectSubInfo(Object current, Object total) {
+    return '$current/$total회';
+  }
+
+  @override
+  String get preview => '미리보기';
 }

--- a/lib/project_detail_screen.dart
+++ b/lib/project_detail_screen.dart
@@ -1511,6 +1511,7 @@ class SectionCounterCardWrapper extends ConsumerWidget {
         final amount = spec['amount'] as int? ?? 0;
         final intervalRowsShaping = spec['intervalRows'] as int? ?? 1;
         final startRowShaping = spec['startRow'] as int? ?? 1;
+        final isDirect = spec['mode'] == 'direct';
 
         int shapingCompleted = 0;
         int nextActionRow = startRowShaping;
@@ -1553,6 +1554,7 @@ class SectionCounterCardWrapper extends ConsumerWidget {
             backgroundColor: backgroundColor,
             isCompleted: isCompleted,
             isActionRow: effectiveValue == nextActionRow && !isCompleted,
+            isDirect: isDirect,
             onLinkTap: () {
               if (counter.linkState == LinkState.linked) {
                 appDb.unlinkSectionCounter(

--- a/lib/widgets/add_shaping_counter_sheet.dart
+++ b/lib/widgets/add_shaping_counter_sheet.dart
@@ -6,6 +6,8 @@ import 'package:yarnie/db/app_db.dart';
 import 'package:yarnie/db/di.dart';
 import 'package:yarnie/widgets/number_input_group.dart';
 
+enum _ShapingMode { pattern, direct }
+
 class AddShapingCounterSheet extends ConsumerStatefulWidget {
   final int partId;
   final int initialStartRow;
@@ -30,24 +32,55 @@ class _AddShapingCounterSheetState
   late TextEditingController _intervalController;
   late TextEditingController _totalCountController;
   late TextEditingController _amountController;
+  // Direct mode controller
+  late TextEditingController _rowsDirectController;
+
+  _ShapingMode _mode = _ShapingMode.pattern;
 
   bool get _isEditing => widget.existingCounter != null;
 
   bool get _isValid {
-    final startRow = int.tryParse(_startRowController.text);
-    final interval = int.tryParse(_intervalController.text);
-    final totalCount = int.tryParse(_totalCountController.text);
-    final amount = int.tryParse(_amountController.text);
+    if (_labelController.text.isEmpty) return false;
 
-    return _labelController.text.isNotEmpty &&
-        startRow != null &&
-        startRow > 0 &&
-        interval != null &&
-        interval > 0 &&
-        totalCount != null &&
-        totalCount > 0 &&
-        amount != null &&
-        amount != 0; // 0은 의미 없음
+    final amount = int.tryParse(_amountController.text);
+    if (amount == null || amount == 0) return false;
+
+    if (_mode == _ShapingMode.pattern) {
+      final startRow = int.tryParse(_startRowController.text);
+      final interval = int.tryParse(_intervalController.text);
+      final totalCount = int.tryParse(_totalCountController.text);
+
+      return startRow != null &&
+          startRow > 0 &&
+          interval != null &&
+          interval > 0 &&
+          totalCount != null &&
+          totalCount > 0;
+    } else {
+      // Direct mode validation
+      final rows = _parseDirectRows();
+      return rows.isNotEmpty;
+    }
+  }
+
+  List<int> _parseDirectRows() {
+    final text = _rowsDirectController.text.trim();
+    if (text.isEmpty) return [];
+
+    final parts = text.split(RegExp(r'[,，\s]+'));
+    final rows = <int>[];
+    for (final part in parts) {
+      final trimmed = part.trim();
+      if (trimmed.isEmpty) continue;
+      final val = int.tryParse(trimmed);
+      if (val == null || val <= 0) return []; // invalid
+      rows.add(val);
+    }
+
+    // Sort and deduplicate
+    rows.sort();
+    final unique = rows.toSet().toList();
+    return unique;
   }
 
   @override
@@ -65,29 +98,42 @@ class _AddShapingCounterSheetState
     String interval = '';
     String totalCount = '';
     String amount = '';
+    String rowsDirect = '${widget.initialStartRow}, ';
+    _ShapingMode initialMode = _ShapingMode.pattern;
 
     if (_isEditing) {
       label = widget.existingCounter!.name;
       try {
         final spec = jsonDecode(widget.existingCounter!.specJson);
-        startRow = spec['startRow']?.toString() ?? startRow;
-        interval = spec['intervalRows']?.toString() ?? '';
-        totalCount = spec['totalCount']?.toString() ?? '';
         amount = spec['amount']?.toString() ?? '';
+
+        final specMode = spec['mode']?.toString();
+        if (specMode == 'direct') {
+          initialMode = _ShapingMode.direct;
+          final List<dynamic> rows = spec['rows'] ?? [];
+          rowsDirect = rows.join(', ');
+        } else {
+          startRow = spec['startRow']?.toString() ?? startRow;
+          interval = spec['intervalRows']?.toString() ?? '';
+          totalCount = spec['totalCount']?.toString() ?? '';
+        }
       } catch (_) {}
     }
 
+    _mode = initialMode;
     _labelController = TextEditingController(text: label);
     _startRowController = TextEditingController(text: startRow);
     _intervalController = TextEditingController(text: interval);
     _totalCountController = TextEditingController(text: totalCount);
     _amountController = TextEditingController(text: amount);
+    _rowsDirectController = TextEditingController(text: rowsDirect);
 
     _labelController.addListener(_updateState);
     _startRowController.addListener(_updateState);
     _intervalController.addListener(_updateState);
     _totalCountController.addListener(_updateState);
     _amountController.addListener(_updateState);
+    _rowsDirectController.addListener(_updateState);
 
     _initialized = true;
   }
@@ -104,12 +150,14 @@ class _AddShapingCounterSheetState
       _intervalController.removeListener(_updateState);
       _totalCountController.removeListener(_updateState);
       _amountController.removeListener(_updateState);
+      _rowsDirectController.removeListener(_updateState);
 
       _labelController.dispose();
       _startRowController.dispose();
       _intervalController.dispose();
       _totalCountController.dispose();
       _amountController.dispose();
+      _rowsDirectController.dispose();
     }
     super.dispose();
   }
@@ -118,21 +166,39 @@ class _AddShapingCounterSheetState
     if (!_isValid) return;
 
     final name = _labelController.text.trim();
-    final startRow = int.parse(_startRowController.text);
-    final interval = int.parse(_intervalController.text);
-    final totalCount = int.parse(_totalCountController.text);
     final amount = int.parse(_amountController.text);
 
-    // Spec JSON Construction
-    final spec = {
-      'type': 'shaping',
-      'startRow': startRow,
-      'intervalRows': interval,
-      'totalCount': totalCount,
-      'amount': amount,
-      'targetInfo':
-          '매 ${interval}행마다 ${amount > 0 ? "+$amount" : amount}${AppLocalizations.of(context)!.stitch} × $totalCount회',
-    };
+    Map<String, dynamic> spec;
+
+    if (_mode == _ShapingMode.pattern) {
+      final startRow = int.parse(_startRowController.text);
+      final interval = int.parse(_intervalController.text);
+      final totalCount = int.parse(_totalCountController.text);
+
+      spec = {
+        'type': 'shaping',
+        'mode': 'pattern',
+        'startRow': startRow,
+        'intervalRows': interval,
+        'totalCount': totalCount,
+        'amount': amount,
+        'targetInfo':
+            '매 ${interval}행마다 ${amount > 0 ? "+$amount" : amount}${AppLocalizations.of(context)!.stitch} × $totalCount회',
+      };
+    } else {
+      // Direct mode
+      final rows = _parseDirectRows();
+      spec = {
+        'type': 'shaping',
+        'mode': 'direct',
+        'startRow': rows.first,
+        'rows': rows,
+        'amount': amount,
+        'totalCount': rows.length,
+        'targetInfo':
+            '${rows.join(", ")}행에서 ${amount > 0 ? "+$amount" : amount}${AppLocalizations.of(context)!.stitch}',
+      };
+    }
 
     try {
       if (_isEditing) {
@@ -236,33 +302,46 @@ class _AddShapingCounterSheetState
                     children: [
                       _buildLabelField(),
                       const SizedBox(height: 16),
-
-                      NumberInputGroup(
-                        label: AppLocalizations.of(context)!.startRow,
-                        controller: _startRowController,
-                        hintText: '19',
-                        min: 1,
-                        onChanged: _updateState,
-                      ),
+                      _buildModeSegment(),
                       const SizedBox(height: 16),
 
-                      NumberInputGroup(
-                        label: AppLocalizations.of(context)!.intervalRows,
-                        controller: _intervalController,
-                        hintText: AppLocalizations.of(context)!.intervalHint,
-                        min: 1,
-                        onChanged: _updateState,
-                      ),
-                      const SizedBox(height: 16),
+                      if (_mode == _ShapingMode.pattern) ...[
+                        // Pattern mode fields
+                        NumberInputGroup(
+                          label: AppLocalizations.of(context)!.startRow,
+                          controller: _startRowController,
+                          hintText: '19',
+                          min: 1,
+                          onChanged: _updateState,
+                        ),
+                        const SizedBox(height: 16),
 
-                      NumberInputGroup(
-                        label: AppLocalizations.of(context)!.totalTimes,
-                        controller: _totalCountController,
-                        hintText: AppLocalizations.of(context)!.timesHint,
-                        min: 1,
-                        onChanged: _updateState,
-                      ),
-                      const SizedBox(height: 16),
+                        NumberInputGroup(
+                          label: AppLocalizations.of(context)!.intervalRows,
+                          controller: _intervalController,
+                          hintText: AppLocalizations.of(context)!.intervalHint,
+                          min: 1,
+                          onChanged: _updateState,
+                        ),
+                        const SizedBox(height: 16),
+
+                        NumberInputGroup(
+                          label: AppLocalizations.of(context)!.totalTimes,
+                          controller: _totalCountController,
+                          hintText: AppLocalizations.of(context)!.timesHint,
+                          min: 1,
+                          onChanged: _updateState,
+                        ),
+                        if (_buildPatternPreview() != null) ...[
+                          const SizedBox(height: 6),
+                          _buildPatternPreview()!,
+                        ],
+                        const SizedBox(height: 16),
+                      ] else ...[
+                        // Direct mode fields
+                        _buildDirectRowsField(),
+                        const SizedBox(height: 16),
+                      ],
 
                       NumberInputGroup(
                         label: AppLocalizations.of(context)!.stitchChange,
@@ -394,4 +473,174 @@ class _AddShapingCounterSheetState
       ],
     );
   }
+
+  Widget _buildModeSegment() {
+    final l10n = AppLocalizations.of(context)!;
+    return Container(
+      height: 36,
+      padding: const EdgeInsets.all(2),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF3F3F5),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          _buildSegmentButton(
+            label: l10n.shapingModePattern,
+            isSelected: _mode == _ShapingMode.pattern,
+            onTap: () => setState(() => _mode = _ShapingMode.pattern),
+          ),
+          _buildSegmentButton(
+            label: l10n.shapingModeDirect,
+            isSelected: _mode == _ShapingMode.direct,
+            onTap: () => setState(() => _mode = _ShapingMode.direct),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSegmentButton({
+    required String label,
+    required bool isSelected,
+    required VoidCallback onTap,
+  }) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeInOut,
+          height: double.infinity,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: isSelected
+                ? Theme.of(context).colorScheme.surface
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(6),
+            boxShadow: isSelected
+                ? [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.08),
+                      blurRadius: 2,
+                      offset: const Offset(0, 1),
+                    ),
+                  ]
+                : null,
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+              color: isSelected
+                  ? Theme.of(context).colorScheme.onSurface
+                  : Theme.of(context).colorScheme.onSurfaceVariant,
+              letterSpacing: -0.15,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDirectRowsField() {
+    final l10n = AppLocalizations.of(context)!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.shapingRowsLabel,
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+            color: Theme.of(context).colorScheme.onSurface,
+            letterSpacing: -0.15,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          height: 48,
+          padding: EdgeInsets.symmetric(horizontal: 12),
+          decoration: BoxDecoration(
+            color: const Color(0xFFF3F3F5),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: TextField(
+            controller: _rowsDirectController,
+            style: TextStyle(
+              fontSize: 16,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+            keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: true),
+            decoration: InputDecoration(
+              border: InputBorder.none,
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(vertical: 14),
+              hintText: l10n.shapingRowsHint,
+              hintStyle: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          l10n.shapingRowsHelper,
+          style: TextStyle(
+            fontSize: 12,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget? _buildPatternPreview() {
+    final start = int.tryParse(_startRowController.text);
+    final interval = int.tryParse(_intervalController.text);
+    final count = int.tryParse(_totalCountController.text);
+
+    if (start == null || interval == null || count == null || count <= 0) {
+      return null;
+    }
+
+    final limit = count > 10 ? 10 : count;
+    final List<int> rows = [];
+    for (int i = 0; i < limit; i++) {
+      rows.add(start + (i * interval));
+    }
+
+    String previewStr = rows.join(', ');
+    if (count > limit) {
+      previewStr += ' ...';
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(left: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.visibility_outlined,
+            size: 14,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              '${AppLocalizations.of(context)!.preview}: $previewStr',
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                letterSpacing: -0.15,
+                height: 1.2,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }
+

--- a/lib/widgets/counter_card/length_counter_card.dart
+++ b/lib/widgets/counter_card/length_counter_card.dart
@@ -92,7 +92,7 @@ class LengthCounterCard extends StatelessWidget {
         ],
       ),
       bottomToolbar: CounterCardToolbar(
-        infoText: '$startRow~$endRow${AppLocalizations.of(context)!.stitch}',
+        infoText: '$startRow~$endRow${AppLocalizations.of(context)!.row}',
         showLinkButton: true,
         isLinked: isLinked,
         onLinkTap: onLinkTap,

--- a/lib/widgets/counter_card/shaping_counter_card.dart
+++ b/lib/widgets/counter_card/shaping_counter_card.dart
@@ -17,6 +17,7 @@ class ShapingCounterCard extends StatelessWidget {
   final Color? backgroundColor;
   final bool isCompleted;
   final bool isActionRow; // 현재 행이 코 줄임/늘림을 실행해야 하는 행인지 여부
+  final bool isDirect; // 직접 입력 모드 여부
 
   const ShapingCounterCard({
     super.key,
@@ -34,6 +35,7 @@ class ShapingCounterCard extends StatelessWidget {
     this.backgroundColor,
     this.isCompleted = false,
     this.isActionRow = false,
+    this.isDirect = false,
   });
 
   @override
@@ -90,7 +92,7 @@ class ShapingCounterCard extends StatelessWidget {
             )
           else if (isActionRow)
             Container(
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
               decoration: BoxDecoration(
                 color: color.withValues(alpha: 0.15),
                 borderRadius: BorderRadius.circular(6),
@@ -98,7 +100,7 @@ class ShapingCounterCard extends StatelessWidget {
               child: Text(
                 l10n.shapingActionNow,
                 style: TextStyle(
-                  fontSize: 18,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: color,
                   letterSpacing: -0.3,
@@ -106,26 +108,34 @@ class ShapingCounterCard extends StatelessWidget {
               ),
             )
           else
-            Text(
-              l10n.shapingActionNotYet(nextActionRow), 
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.w400,
-                color: Theme.of(context).colorScheme.onSurface,
-                letterSpacing: -0.44,
-                height: 1.4,
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Text(
+                l10n.shapingWorkEven, 
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  letterSpacing: -0.3,
+                ),
               ),
             ),
-          
-          // Sub Info
-          Text(
-            '${intervalRows}${l10n.stitch} · $currentCount/${totalCount}회',
-            style: TextStyle(
-              fontSize: 12,
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-              letterSpacing: -0.15,
+            
+          if (!isCompleted && !isActionRow) ...[
+            const SizedBox(height: 2),
+            Text(
+              l10n.shapingNextActionRow(nextActionRow),
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                letterSpacing: -0.15,
+              ),
             ),
-          ),
+          ],
         ],
       ),
       bottomToolbar: CounterCardToolbar(


### PR DESCRIPTION
비규칙적인 코 증감 패턴을 지원하는 직접 입력 모드 추가
- AddShapingCounterSheet에 패턴/직접입력 segmented control 추가
- 직접 입력 모드: 쉼표로 구분된 단수 리스트 입력 지원
- 패턴 모드: 반복횟수 입력 후 생성될 단수 미리보기 표시
- app_db: _expandSectionRuns에서 direct 모드 section runs 생성 로직 추가
- ShapingCounterCard: Work even 박스 스타일 적용, sub info에 다음 행 표시
- shapingActionNotYet → shapingWorkEven + shapingNextActionRow로 분리