### PR TITLE
feat: 앱 정보 내 고객 지원 및 정책 관련 링크 연동

### DIFF
--- a/lib/features/my/screens/open_source_licenses_screen.dart
+++ b/lib/features/my/screens/open_source_licenses_screen.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:yarnie/l10n/app_localizations.dart';
+import 'package:yarnie/theme/text_styles.dart';
+
+class OpenSourceLicensesScreen extends StatefulWidget {
+  const OpenSourceLicensesScreen({super.key});
+
+  @override
+  State<OpenSourceLicensesScreen> createState() => _OpenSourceLicensesScreenState();
+}
+
+class _OpenSourceLicensesScreenState extends State<OpenSourceLicensesScreen> {
+  final Map<String, List<LicenseEntry>> _licenses = {};
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadLicenses();
+  }
+
+  Future<void> _loadLicenses() async {
+    final Map<String, List<LicenseEntry>> packages = {};
+    
+    await for (final license in LicenseRegistry.licenses) {
+      for (final package in license.packages) {
+        if (!packages.containsKey(package)) {
+          packages[package] = [];
+        }
+        packages[package]!.add(license);
+      }
+    }
+
+    final sortedKeys = packages.keys.toList()..sort();
+    final sortedPackages = {for (var k in sortedKeys) k: packages[k]!};
+
+    if (mounted) {
+      setState(() {
+        _licenses.addAll(sortedPackages);
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      appBar: AppBar(
+        title: Text(
+          AppLocalizations.of(context)!.openSourceLicense,
+          style: AppTextStyles.titleH1.copyWith(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        centerTitle: true,
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.separated(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+              itemCount: _licenses.keys.length,
+              separatorBuilder: (context, index) => Divider(
+                height: 1, 
+                color: Theme.of(context).colorScheme.outline.withOpacity(0.5),
+              ),
+              itemBuilder: (context, index) {
+                final packageName = _licenses.keys.elementAt(index);
+                final entries = _licenses[packageName]!;
+                
+                return _LicenseItem(
+                  packageName: packageName,
+                  entries: entries,
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _LicenseItem extends StatelessWidget {
+  final String packageName;
+  final List<LicenseEntry> entries;
+
+  const _LicenseItem({
+    required this.packageName,
+    required this.entries,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => _LicenseDetailScreen(
+              packageName: packageName,
+              entries: entries,
+            ),
+          ),
+        );
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 20),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Expanded(
+              child: Text(
+                packageName,
+                style: AppTextStyles.bodyM.copyWith(
+                  fontWeight: FontWeight.w500,
+                  fontSize: 16,
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+              ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              color: Theme.of(context).colorScheme.onSurfaceVariant.withOpacity(0.5),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LicenseDetailScreen extends StatelessWidget {
+  final String packageName;
+  final List<LicenseEntry> entries;
+
+  const _LicenseDetailScreen({
+    required this.packageName,
+    required this.entries,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      appBar: AppBar(
+        title: Text(
+          packageName,
+          style: AppTextStyles.titleH1.copyWith(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+        itemCount: entries.length,
+        itemBuilder: (context, index) {
+          final entry = entries[index];
+          final paragraphs = entry.paragraphs.map((p) => p.text).join('\n\n');
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 32),
+            child: Text(
+              paragraphs,
+              style: AppTextStyles.bodyM.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 13,
+                height: 1.6,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/my/widgets/app_info_sheet.dart
+++ b/lib/features/my/widgets/app_info_sheet.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:yarnie/l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:yarnie/theme/text_styles.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:yarnie/features/my/screens/open_source_licenses_screen.dart';
 
 class AppInfoSheet extends StatelessWidget {
   const AppInfoSheet({super.key});
@@ -123,25 +125,50 @@ class AppInfoSheet extends StatelessWidget {
                       context,
                       text: AppLocalizations.of(context)!.sendFeedback,
                       iconPath: 'assets/icons/feedback.svg',
-                      onTap: () {},
+                      onTap: () async {
+                        final Uri emailLaunchUri = Uri(
+                          scheme: 'mailto',
+                          path: 'yarnie.support@gmail.com',
+                        );
+                        if (!await launchUrl(emailLaunchUri)) {
+                          debugPrint('Could not launch $emailLaunchUri');
+                        }
+                      },
                     ),
                     const SizedBox(height: 8),
                     _buildButton(
                       context,
                       text: AppLocalizations.of(context)!.privacyPolicy,
-                      onTap: () {},
+                      onTap: () async {
+                        final url = Uri.parse('https://sprinkle-crawdad-024.notion.site/Privacy-Policy-34308fa3261c8053aaa3c3b21e26d04b?source=copy_link');
+                        if (!await launchUrl(url, mode: LaunchMode.externalApplication)) {
+                          debugPrint('Could not launch $url');
+                        }
+                      },
                     ),
                     const SizedBox(height: 8),
                     _buildButton(
                       context,
                       text: AppLocalizations.of(context)!.termsOfService,
-                      onTap: () {},
+                      onTap: () async {
+                        final url = Uri.parse('https://sprinkle-crawdad-024.notion.site/Terms-of-Service-34408fa3261c80679ec6fab334633443?source=copy_link');
+                        if (!await launchUrl(url, mode: LaunchMode.externalApplication)) {
+                          debugPrint('Could not launch $url');
+                        }
+                      },
                     ),
                     const SizedBox(height: 8),
                     _buildButton(
                       context,
                       text: AppLocalizations.of(context)!.openSourceLicense,
-                      onTap: () {},
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const OpenSourceLicensesScreen(),
+                          ),
+                        );
+                      },
                     ),
                   ],
                 ),


### PR DESCRIPTION
- url_launcher를 활용하여 개인정보처리방침 및 이용약관 노션 링크(externalApplication) 연결
- '피드백 보내기' 버튼에 mailto: 스킴을 적용하여 기본 이메일 앱(yarnie.support@gmail.com) 작성 화면으로 즉시 연결되도록 구현
- 가독성을 위해 Flutter 기본 showLicensePage 대신 앱 테마와 어울리고 패키지별로 깔끔하게 정리된 OpenSourceLicensesScreen 신규 개발 및 맵핑 적용