### PR TITLE
feat: 환경별(Release/Debug) 애드몹 광고 단위 ID 분기 처리 적용

### DIFF
--- a/lib/common/ad_helper.dart
+++ b/lib/common/ad_helper.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+
+class AdHelper {
+  static String get projectListBannerId {
+    if (kReleaseMode) {
+      return Platform.isAndroid
+          ? 'ca-app-pub-3766691232792823/9145792738'
+          : 'ca-app-pub-3766691232792823/4532727908';
+    } else {
+      return Platform.isAndroid
+          ? 'ca-app-pub-3940256099942544/6300978111'
+          : 'ca-app-pub-3940256099942544/2934735716';
+    }
+  }
+
+  static String get projectDetailBannerId {
+    if (kReleaseMode) {
+      return Platform.isAndroid
+          ? 'ca-app-pub-3766691232792823/4253618194'
+          : 'ca-app-pub-3766691232792823/1090935677';
+    } else {
+      return Platform.isAndroid
+          ? 'ca-app-pub-3940256099942544/6300978111'
+          : 'ca-app-pub-3940256099942544/2934735716';
+    }
+  }
+
+  static String get homeBannerId {
+    if (kReleaseMode) {
+      return Platform.isAndroid
+          ? 'ca-app-pub-3766691232792823/3341959766'
+          : 'ca-app-pub-3766691232792823/4655041435';
+    } else {
+      return Platform.isAndroid
+          ? 'ca-app-pub-3940256099942544/6300978111'
+          : 'ca-app-pub-3940256099942544/2934735716';
+    }
+  }
+
+  static String get exitDialogBannerId {
+    if (kReleaseMode) {
+      return Platform.isAndroid
+          ? 'ca-app-pub-3766691232792823/6277146303'
+          : 'ca-app-pub-3766691232792823/8290768840'; // 사용 안함
+    } else {
+      return Platform.isAndroid
+          ? 'ca-app-pub-3940256099942544/6300978111'
+          : 'ca-app-pub-3940256099942544/2934735716';
+    }
+  }
+}

--- a/lib/features/home/home_root.dart
+++ b/lib/features/home/home_root.dart
@@ -15,6 +15,7 @@ import 'package:yarnie/widgets/common_banner_ad.dart';
 import 'package:yarnie/widgets/ad_visibility_wrapper.dart';
 import 'package:yarnie/core/providers/premium_provider.dart';
 import 'package:yarnie/core/premium/premium_policy.dart';
+import 'package:yarnie/common/ad_helper.dart';
 
 const _kGuideCardDismissedKey = 'home_guide_card_dismissed';
 
@@ -129,9 +130,7 @@ class _HomeRootState extends ConsumerState<HomeRoot> {
           ? null
           : AdVisibilityWrapper(
               child: CommonBannerAdWidget(
-                adUnitId: Platform.isAndroid
-                    ? 'ca-app-pub-3940256099942544/6300978111'
-                    : 'ca-app-pub-3940256099942544/2934735716',
+                adUnitId: AdHelper.homeBannerId,
               ),
             ),
       body: SafeArea(

--- a/lib/features/projects/projects_root.dart
+++ b/lib/features/projects/projects_root.dart
@@ -18,6 +18,7 @@ import '../../widgets/ad_visibility_wrapper.dart';
 import '../../core/providers/premium_provider.dart';
 import '../../core/premium/premium_policy.dart';
 import '../../common/time_helper.dart';
+import '../../common/ad_helper.dart';
 
 /// SharedPreferences 키
 const _kViewModeKey = 'projects_view_mode';
@@ -162,9 +163,7 @@ class _ProjectsRootState extends ConsumerState<ProjectsRoot> {
           ? null
           : AdVisibilityWrapper(
               child: CommonBannerAdWidget(
-                adUnitId: Platform.isAndroid
-                    ? 'ca-app-pub-3940256099942544/6300978111'
-                    : 'ca-app-pub-3940256099942544/2934735716',
+                adUnitId: AdHelper.projectListBannerId,
               ),
             ),
     );

--- a/lib/project_detail_screen.dart
+++ b/lib/project_detail_screen.dart
@@ -12,6 +12,7 @@ import 'package:drift/drift.dart' hide Column;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yarnie/db/app_db.dart';
 import 'package:yarnie/db/di.dart';
+import 'package:yarnie/common/ad_helper.dart';
 import 'package:yarnie/widgets/add_buddy_counter_menu.dart';
 import 'package:yarnie/widgets/add_interval_counter_sheet.dart';
 import 'package:yarnie/widgets/add_length_counter_sheet.dart';
@@ -394,9 +395,7 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
           ? null
           : AdVisibilityWrapper(
               child: CommonBannerAdWidget(
-                adUnitId: Platform.isAndroid
-                    ? 'ca-app-pub-3940256099942544/6300978111'
-                    : 'ca-app-pub-3940256099942544/2934735716',
+                adUnitId: AdHelper.projectDetailBannerId,
               ),
             ),
     );

--- a/lib/widgets/exit_confirm_dialog.dart
+++ b/lib/widgets/exit_confirm_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:yarnie/l10n/app_localizations.dart';
 import 'package:yarnie/widgets/ad_visibility_wrapper.dart';
+import 'package:yarnie/common/ad_helper.dart';
 
 class ExitConfirmDialog extends StatefulWidget {
   const ExitConfirmDialog({super.key});
@@ -22,9 +23,7 @@ class _ExitConfirmDialogState extends State<ExitConfirmDialog> {
   }
 
   void _loadAd() {
-    final adUnitId = Platform.isAndroid
-        ? 'ca-app-pub-3940256099942544/6300978111'
-        : 'ca-app-pub-3940256099942544/2934735716';
+    final adUnitId = AdHelper.exitDialogBannerId;
 
     _bannerAd = BannerAd(
       adUnitId: adUnitId,


### PR DESCRIPTION
- kReleaseMode를 이용해 Release 빌드일 때만 실제 광고가 송출되도록 변경 (Debug 모드에선 구글 제공 테스트 ID 사용)
- AdHelper 클래스를 신규 생성하여 총 4개 영역(홈, 프로젝트 목록, 프로젝트 상세, 앱 종료 팝업)의 애드몹 단위 ID를 모듈화 및 통합 관리
- 무효 트래픽으로 인한 애드몹 계정 정지 위험 방지 적용 완비