### PR TITLE
feat: 프로젝트 기본 이미지 변경 및 iOS 미디어 권한 추가

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,6 +47,10 @@
 			<string>UIInterfaceOrientationLandscapeLeft</string>
 			<string>UIInterfaceOrientationLandscapeRight</string>
 		</array>
+		<key>NSCameraUsageDescription</key>
+		<string>프로젝트 사진을 촬영하기 위해 카메라에 접근합니다.</string>
+		<key>NSPhotoLibraryUsageDescription</key>
+		<string>프로젝트에 이미지를 첨부하기 위해 사진 라이브러리에 접근합니다.</string>
 		<key>UIStatusBarHidden</key>
 		<false/>
 	</dict>

--- a/lib/features/projects/projects_root.dart
+++ b/lib/features/projects/projects_root.dart
@@ -19,6 +19,7 @@ import '../../core/providers/premium_provider.dart';
 import '../../core/premium/premium_policy.dart';
 import '../../common/time_helper.dart';
 import '../../common/ad_helper.dart';
+import '../../theme/app_theme.dart';
 
 /// SharedPreferences 키
 const _kViewModeKey = 'projects_view_mode';
@@ -505,12 +506,11 @@ class _LargeProjectCard extends StatelessWidget {
             fit: StackFit.expand,
             children: [
               // 배경 이미지
-              project.imagePath != null
-                  ? ProjectImage(
-                      imagePath: project.imagePath,
-                      fit: BoxFit.cover,
-                    )
-                  : Container(color: const Color(0xFFD9D9D9)),
+              ProjectImage(
+                imagePath: project.imagePath,
+                fit: BoxFit.cover,
+                fallbackPadding: 48,
+              ),
               // 하단 정보 섹션
               Positioned(
                 left: 0,
@@ -521,10 +521,15 @@ class _LargeProjectCard extends StatelessWidget {
                     gradient: LinearGradient(
                       begin: Alignment.bottomCenter,
                       end: Alignment.topCenter,
-                      colors: [
-                        const Color.fromRGBO(0, 0, 0, 0.6),
-                        const Color.fromRGBO(0, 0, 0, 0.0),
-                      ],
+                      colors: project.imagePath == null
+                          ? [
+                              AppColors.primary.withOpacity(0.85),
+                              AppColors.primary.withOpacity(0.0),
+                            ]
+                          : [
+                              const Color.fromRGBO(0, 0, 0, 0.6),
+                              const Color.fromRGBO(0, 0, 0, 0.0),
+                            ],
                     ),
                   ),
                   child: Padding(
@@ -707,14 +712,11 @@ class _SmallProjectCard extends StatelessWidget {
           children: [
             // 이미지 영역
             Container(
-              color: const Color(0xFFD9D9D9),
-              child: project.imagePath != null
-                  ? ProjectImage(
-                      imagePath: project.imagePath,
-                      fit: BoxFit.cover,
-                      placeholder: _placeholderImage(context),
-                    )
-                  : _placeholderImage(context),
+              color: Colors.white,
+              child: ProjectImage(
+                imagePath: project.imagePath,
+                fit: BoxFit.cover,
+              ),
             ),
 
             // 좌측 상단 태그
@@ -771,15 +773,7 @@ class _SmallProjectCard extends StatelessWidget {
     );
   }
 
-  Widget _placeholderImage(BuildContext context) {
-    return Center(
-      child: Icon(
-        Icons.image,
-        size: 48,
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
-    );
-  }
+
 
   List<Tag> _getProjectTags() {
     if (project.tagIds == null || project.tagIds!.isEmpty) return [];

--- a/lib/project_info_screen.dart
+++ b/lib/project_info_screen.dart
@@ -155,40 +155,10 @@ class ProjectInfoSheet extends ConsumerWidget {
                               width: 240,
                               height: 135,
                               child:
-                                  (project.imagePath != null &&
-                                      project.imagePath!.isNotEmpty)
-                                  ? ProjectImage(
-                                      imagePath: project.imagePath,
-                                      fit: BoxFit.cover,
-                                      placeholder: Container(
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.surfaceContainerHighest,
-                                        child: Center(
-                                          child: Icon(
-                                            Icons.image_not_supported_outlined,
-                                            size: 40,
-                                            color: Theme.of(
-                                              context,
-                                            ).colorScheme.onSurfaceVariant,
-                                          ),
-                                        ),
-                                      ),
-                                    )
-                                  : Container(
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.surfaceContainerHighest,
-                                      child: Center(
-                                        child: Icon(
-                                          Icons.image_outlined,
-                                          size: 40,
-                                          color: Theme.of(
-                                            context,
-                                          ).colorScheme.onSurfaceVariant,
-                                        ),
-                                      ),
-                                    ),
+                                  ProjectImage(
+                                    imagePath: project.imagePath,
+                                    fit: BoxFit.cover,
+                                  ),
                             ),
                           ),
                         ),

--- a/lib/widgets/project_image.dart
+++ b/lib/widgets/project_image.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:yarnie/theme/app_theme.dart';
 import '../../core/utils/project_image_utils.dart';
 
 /// 프로젝트 이미지를 표시하는 위젯
@@ -10,32 +11,46 @@ class ProjectImage extends StatelessWidget {
   final String? imagePath;
   final BoxFit fit;
   final Widget? placeholder;
+  final double fallbackPadding;
 
   const ProjectImage({
     super.key,
     required this.imagePath,
     this.fit = BoxFit.cover,
     this.placeholder,
+    this.fallbackPadding = 16.0,
   });
 
   @override
   Widget build(BuildContext context) {
+    final defaultImage = placeholder ??
+        Container(
+          color: AppColors.secondary,
+          alignment: Alignment.center,
+          child: Padding(
+            padding: EdgeInsets.all(fallbackPadding),
+            child: Image.asset(
+              'assets/splash_icon.png',
+              fit: BoxFit.contain,
+            ),
+          ),
+        );
+
     if (imagePath == null) {
-      return placeholder ?? Container(color: const Color(0xFFD9D9D9));
+      return defaultImage;
     }
 
     return FutureBuilder<String?>(
       future: ProjectImageUtils.toAbsolutePath(imagePath),
       builder: (context, snapshot) {
         if (!snapshot.hasData || snapshot.data == null) {
-          return placeholder ?? Container(color: const Color(0xFFD9D9D9));
+          return defaultImage;
         }
         final absPath = snapshot.data!;
         return Image.file(
           File(absPath),
           fit: fit,
-          errorBuilder: (_, __, ___) =>
-              placeholder ?? Container(color: const Color(0xFFD9D9D9)),
+          errorBuilder: (_, __, ___) => defaultImage,
         );
       },
     );

--- a/lib/widgets/project_list_tile.dart
+++ b/lib/widgets/project_list_tile.dart
@@ -48,15 +48,14 @@ class ProjectListTile extends StatelessWidget {
                   color: const Color(0xFFD9D9D9),
                   borderRadius: BorderRadius.circular(4),
                 ),
-                child: project.imagePath != null
-                    ? ClipRRect(
-                        borderRadius: BorderRadius.circular(4),
-                        child: ProjectImage(
-                          imagePath: project.imagePath,
-                          fit: BoxFit.cover,
-                        ),
-                      )
-                    : Container(color: const Color(0xFFD9D9D9)),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: ProjectImage(
+                    imagePath: project.imagePath,
+                    fit: BoxFit.cover,
+                    fallbackPadding: 0,
+                  ),
+                ),
               ),
               const SizedBox(width: 16),
               // 정보

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+5
+version: 1.0.0+6
 
 environment:
   sdk: ^3.8.1
@@ -88,6 +88,7 @@ flutter:
   assets:
     - assets/icons/
     - assets/images/
+    - assets/splash_icon.png
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
- iOS Info.plist에 카메라(NSCameraUsageDescription) 및 사진 라이브러리(NSPhotoLibraryUsageDescription) 접근 안내 문구 추가 (앱 심사 필수사항)
- 이미지가 없는 프로젝트의 기본 이미지를 회색 배경 대신 흰 여백이 포함된 스플래시 아이콘(assets/splash_icon.png)으로 일괄 변경
- 뷰 모드(Large, Small, List 등)에 따라 기본 스플래시 아이콘의 여백(padding)이 맞춤형으로 렌더링되도록 ProjectImage 위젯 개선
- 큰 카드 뷰에서 커스텀 이미지가 없을 때만 테마(primary) 색상 오버레이가 가미되도록 조건부 그라데이션 적용
- 버전 및 빌드 넘버 업데이트 (1.0.0+6)